### PR TITLE
Move to sort.Sort from slices.Sort

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -4,8 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
-
-	"golang.org/x/exp/slices"
 )
 
 // Pollard is a representation of the utreexo forest using a collection of
@@ -163,7 +161,7 @@ func (p *Pollard) calculateNewRoot(node *polNode) *polNode {
 
 // remove removes all the positions that are passed in.
 func (p *Pollard) remove(dels []uint64) error {
-	slices.Sort(dels)
+	sort.Slice(dels, func(a, b int) bool { return dels[a] < dels[b] })
 
 	totalRows := treeRows(p.numLeaves)
 	dels = deTwin(dels, totalRows)
@@ -332,7 +330,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64) error {
 	copy(dels, origDels)
 
 	// Sort before detwining.
-	slices.Sort(dels)
+	sort.Slice(dels, func(a, b int) bool { return dels[a] < dels[b] })
 	dels = deTwin(dels, treeRows(p.numLeaves))
 	for i := len(dels) - 1; i >= 0; i-- {
 		del := dels[i]

--- a/prove.go
+++ b/prove.go
@@ -4,8 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
-
-	"golang.org/x/exp/slices"
 )
 
 // Proof is the inclusion-proof for multiple leaves.
@@ -37,7 +35,8 @@ type Proof struct {
 func (p *Proof) ToString() string {
 	targs := make([]uint64, len(p.Targets))
 	copy(targs, p.Targets)
-	slices.Sort(targs)
+	sort.Slice(targs, func(a, b int) bool { return targs[a] < targs[b] })
+
 	s := fmt.Sprintf("%d targets: ", len(targs))
 	for _, t := range targs {
 		s += fmt.Sprintf("%d ", t)
@@ -80,7 +79,7 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 	// locality or performance.
 	sortedTargets := make([]uint64, len(proof.Targets))
 	copy(sortedTargets, proof.Targets)
-	slices.Sort(sortedTargets)
+	sort.Slice(sortedTargets, func(a, b int) bool { return sortedTargets[a] < sortedTargets[b] })
 
 	// Get the positions of all the hashes that are needed to prove the targets
 	proofPositions := proofPositions(sortedTargets, p.numLeaves, treeRows(p.numLeaves))

--- a/utils.go
+++ b/utils.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/bits"
 	"sort"
-
-	"golang.org/x/exp/slices"
 )
 
 // parentHash returns the hash of the left and right hashes passed in.
@@ -380,7 +378,7 @@ func proofPositions(targets []uint64, numLeaves uint64, forestRows uint8) []uint
 		rowTargs := extractRow(targets, forestRows, row)
 
 		rowTargs = append(rowTargs, nextTargets...)
-		slices.Sort(rowTargs)
+		sort.Slice(rowTargs, func(a, b int) bool { return rowTargs[a] < rowTargs[b] })
 
 		// Reset nextTargets
 		nextTargets = nextTargets[:0]

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package utreexo
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ func TestDeTwinRand(t *testing.T) {
 			dels = append(dels, randNum)
 		}
 
-		slices.Sort(dels)
+		sort.Slice(dels, func(a, b int) bool { return dels[a] < dels[b] })
 		origDels := make([]uint64, len(dels))
 		copy(origDels, dels)
 


### PR DESCRIPTION
Most of the sorts that are being used are very basic and can be done
with the std lib. There's now only one call to the slices package in the
library, making it easier to switch over to a different library as the
slices package is subject to change.