### PR TITLE
go.yml: Change golangci-lint link

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2"
       - name: Build
         env:
           GO111MODULE: "on"


### PR DESCRIPTION
install.goreleaser.com was down, resulting in a failed CI. Changing the link to github. If github is down, we can't run the CI anyways so it's ok.