### PR TITLE
prove, stump: Don't reverse hashes in calculateRoots

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -141,7 +141,7 @@ func (p *Pollard) Verify(delHashes []Hash, proof Proof) error {
 	rootMatches := 0
 	for i := range p.roots {
 		if len(rootCandidates) > rootMatches &&
-			p.roots[i].data == rootCandidates[rootMatches] {
+			p.roots[len(p.roots)-(i+1)].data == rootCandidates[rootMatches] {
 			rootMatches++
 		}
 	}
@@ -214,13 +214,6 @@ func calculateRoots(numLeaves uint64, delHashes []Hash, proof Proof) []Hash {
 				nextProves = append(nextProves, nextProve)
 			}
 		}
-	}
-
-	// The roots are organized from the greatest position to the smallest but
-	// since we've calculated up, the calculated roots are in smallest to greatest
-	// order. Reversing makes the roots all be in an expected order.
-	for i, j := 0, len(calculatedRootHashes)-1; i < j; i, j = i+1, j-1 {
-		calculatedRootHashes[i], calculatedRootHashes[j] = calculatedRootHashes[j], calculatedRootHashes[i]
 	}
 
 	return calculatedRootHashes

--- a/stump.go
+++ b/stump.go
@@ -24,7 +24,9 @@ func UpdateStump(delHashes, addHashes []Hash, proof Proof, stump Stump) (Stump, 
 
 	roots := make([]Hash, len(stump.Roots))
 	idx := 0
-	for i, root := range stump.Roots {
+	for i := len(stump.Roots) - 1; i >= 0; i-- {
+		root := stump.Roots[i]
+
 		if idx < len(rootCandidates) && root == rootCandidates[idx] {
 			roots[i] = modifiedRoots[idx]
 			idx++
@@ -48,7 +50,7 @@ func StumpVerify(stump Stump, delHashes []Hash, proof Proof) ([]Hash, error) {
 	rootMatches := 0
 	for i := range stump.Roots {
 		if len(rootCandidates) > rootMatches &&
-			stump.Roots[i] == rootCandidates[rootMatches] {
+			stump.Roots[len(stump.Roots)-(i+1)] == rootCandidates[rootMatches] {
 			rootMatches++
 		}
 	}


### PR DESCRIPTION
Not reversing saves and extra step and simplifies the code. Just handle
the roots being in smallest to largest order.