### PR TITLE
Prove: Refactor Proof.String()

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -33,14 +33,10 @@ type Proof struct {
 	Proof []Hash
 }
 
-// ToString for debugging, shows the proof
-func (p *Proof) ToString() string {
-	targs := make([]uint64, len(p.Targets))
-	copy(targs, p.Targets)
-	sort.Slice(targs, func(a, b int) bool { return targs[a] < targs[b] })
-
-	s := fmt.Sprintf("%d targets: ", len(targs))
-	for _, t := range targs {
+// String returns a string of the proof. Useful for debugging.
+func (p *Proof) String() string {
+	s := fmt.Sprintf("%d targets: ", len(p.Targets))
+	for _, t := range p.Targets {
 		s += fmt.Sprintf("%d ", t)
 	}
 	s += fmt.Sprintf("\n%d proofs: ", len(p.Proof))


### PR DESCRIPTION
ToString is renamed to just String() as that is more in line with the
standard go library.

Also, the targets are not sorted before printing to show the targets in
their actual order.