### PR TITLE
utils: Return computable positions in proofPositions()

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -80,7 +80,7 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 	sort.Slice(sortedTargets, func(a, b int) bool { return sortedTargets[a] < sortedTargets[b] })
 
 	// Get the positions of all the hashes that are needed to prove the targets
-	proofPositions := proofPositions(sortedTargets, p.numLeaves, treeRows(p.numLeaves))
+	proofPositions, _ := proofPositions(sortedTargets, p.numLeaves, treeRows(p.numLeaves))
 
 	// Fetch all the proofs from the accumulator.
 	proof.Proof = make([]Hash, len(proofPositions))
@@ -373,7 +373,7 @@ func proofAfterDeletion(numLeaves uint64, proof Proof) ([]Hash, Proof) {
 	sort.Slice(targets, func(a, b int) bool { return targets[a] < targets[b] })
 
 	// Use the sorted targets to generate the positions for the proof hashes.
-	proofPos := proofPositions(targets, numLeaves, forestRows)
+	proofPos, _ := proofPositions(targets, numLeaves, forestRows)
 	// Attach a position to each of the proof hashes.
 	hnp := toHashAndPos(proofPos, proof.Proof)
 

--- a/utils.go
+++ b/utils.go
@@ -455,12 +455,13 @@ func extractRow(targets []uint64, forestRows, rowToExtract uint8) []uint64 {
 }
 
 // proofPositions returns all the positions that are needed to prove targets passed in.
-func proofPositions(targets []uint64, numLeaves uint64, forestRows uint8) []uint64 {
-	var nextTargets, proofPositions []uint64
+func proofPositions(targets []uint64, numLeaves uint64, forestRows uint8) ([]uint64, []uint64) {
+	var nextTargets, proofPositions, computedPositions []uint64
 
 	for row := uint8(0); row < forestRows; row++ {
 		rowTargs := extractRow(targets, forestRows, row)
 
+		computedPositions = append(computedPositions, nextTargets...)
 		rowTargs = append(rowTargs, nextTargets...)
 		sort.Slice(rowTargs, func(a, b int) bool { return rowTargs[a] < rowTargs[b] })
 
@@ -537,7 +538,7 @@ func proofPositions(targets []uint64, numLeaves uint64, forestRows uint8) []uint
 		}
 	}
 
-	return proofPositions
+	return proofPositions, computedPositions
 }
 
 // String prints out the whole thing. Only viable for forest that have height of 5 and less.


### PR DESCRIPTION
Returning computable positions is useful for implementations of proof
modifications. Computable positions were originally returned in the
github.com/mit-dci/utreexo repo before removing it as the returned
computable positions were not used. Adding it back in for the proof
modifications.