### PR TITLE
prove: Add GetMissingPositions()

### DIFF
--- a/prove_test.go
+++ b/prove_test.go
@@ -1,0 +1,228 @@
+package utreexo
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+// Grab some random indexes. If minimum is greater than length, nil is returned.
+func randomIndexes(length, minimum int) []int {
+	if minimum > length {
+		return nil
+	}
+	indexes := []int{}
+
+	// Optimization for when the caller wants everything.
+	if minimum == length {
+		indexes = make([]int, length)
+		for i := range indexes {
+			indexes[i] = i
+		}
+
+		return indexes
+	}
+
+	// Loop until we get enough.
+	for len(indexes) < minimum {
+		// Reset the slice first.
+		indexes = indexes[:0]
+
+		i := rand.Intn(length)
+		max := length - 1
+		for i <= max {
+			indexes = append(indexes, i)
+			if max-i <= 0 {
+				break
+			}
+			increment := (rand.Intn(max-i) + i)
+			if increment == 0 {
+				increment++
+			}
+			i += increment
+		}
+	}
+
+	return indexes
+}
+
+// calcDelHashAndProof returns a proof with the missingPositions filled in and the deletion hashes
+// with the hashes of the desired positions.
+func calcDelHashAndProof(p *Pollard, proof Proof, missingPositions, desiredPositions []uint64,
+	leftOutLeaves, leaves []hashAndPos) (Proof, []Hash, error) {
+
+	// Grab all the hashes that are needed from the pollard.
+	neededHashes := []hashAndPos{}
+	sort.Slice(missingPositions, func(a, b int) bool { return missingPositions[a] < missingPositions[b] })
+	for _, pos := range missingPositions {
+		hash := p.getHash(pos)
+		if hash == empty {
+			return Proof{}, nil, fmt.Errorf("Couldn't fetch required hash at position %d", pos)
+		}
+
+		neededHashes = append(neededHashes, hashAndPos{hash, pos})
+	}
+
+	// Attach positions to the proof hashes.
+	proofPos, _ := proofPositions(proof.Targets, p.numLeaves, treeRows(p.numLeaves))
+	currentHashes := toHashAndPos(proofPos, proof.Proof)
+	// Append the needed hashes to the proof.
+	currentHashes = append(currentHashes, neededHashes...)
+
+	// As new targets are added, we're able to calulate positions that we couldn't before. These positions
+	// may already exist as proofs. Remove these as duplicates are not expected during proof verification.
+	_, calculateables := proofPositions(desiredPositions, p.numLeaves, treeRows(p.numLeaves))
+	for _, cal := range calculateables {
+		idx := slices.IndexFunc(currentHashes, func(hnp hashAndPos) bool { return hnp.pos == cal })
+		if idx != -1 {
+			currentHashes = append(currentHashes[:idx], currentHashes[idx+1:]...)
+		}
+	}
+
+	// The newly added targets may be used as proofs. Remove existing duplicates from the proof as these
+	// are not expected during proof verification.
+	for _, leaf := range leftOutLeaves {
+		idx := slices.IndexFunc(currentHashes, func(hnp hashAndPos) bool { return hnp.hash == leaf.hash })
+		if idx != -1 {
+			currentHashes = append(currentHashes[:idx], currentHashes[idx+1:]...)
+		}
+	}
+
+	// Create the proof.
+	newProof := Proof{Targets: append(proof.Targets, desiredPositions...)}
+	// Sort the targets as it needs to match the ordering of the deletion hashes and
+	// the deletions hashes will also be sorted.
+	sort.Slice(newProof.Targets, func(a, b int) bool { return newProof.Targets[a] < newProof.Targets[b] })
+
+	// We need to sort the proof hashes as those are expected to be in order during proof verificatin.
+	sort.Slice(currentHashes, func(a, b int) bool { return currentHashes[a].pos < currentHashes[b].pos })
+	newProof.Proof = make([]Hash, len(currentHashes))
+	for i := range newProof.Proof {
+		newProof.Proof[i] = currentHashes[i].hash
+	}
+
+	// The deletion hashes are leaves + leftOutLeaves. We sort them to match the ordering of the targets.
+	leaves = append(leaves, leftOutLeaves...)
+	sort.Slice(leaves, func(a, b int) bool { return leaves[a].pos < leaves[b].pos })
+	newDelHashes := make([]Hash, len(leaves))
+	for i := range leaves {
+		newDelHashes[i] = leaves[i].hash
+	}
+
+	return newProof, newDelHashes, nil
+}
+
+func FuzzGetMissingPositions(f *testing.F) {
+	var tests = []struct {
+		startLeaves uint32
+		delCount    uint32
+		seed        int64
+	}{
+		{
+			8,
+			3,
+			17,
+		},
+		{
+			6,
+			3,
+			12,
+		},
+	}
+	for _, test := range tests {
+		f.Add(test.startLeaves, test.delCount, test.seed)
+	}
+
+	f.Fuzz(func(t *testing.T, startLeaves uint32, delCount uint32, seed int64) {
+		rand.Seed(seed)
+
+		// It'll error out if we try to delete more than we have. >= since we want
+		// at least 2 leftOver leaf to test.
+		if int(delCount) >= int(startLeaves)-2 {
+			return
+		}
+
+		// Create the starting off pollard.
+		p := NewAccumulator(true)
+		leaves, delHashes, delPos := getAddsAndDels(uint32(p.numLeaves), startLeaves, delCount)
+		err := p.Modify(leaves, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = p.Modify(nil, delHashes, delPos)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Grab the current leaves that exist in the accumulator.
+		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
+		for _, node := range p.nodeMap {
+			currentLeaves = append(currentLeaves,
+				hashAndPos{node.data, p.calculatePosition(node)})
+		}
+		// Sort to have a deterministic order of the currentLeaves. Since maps aren't
+		// guaranteed to have the same order, we need to do this.
+		sort.Slice(currentLeaves, func(a, b int) bool { return currentLeaves[a].pos < currentLeaves[b].pos })
+
+		// Sanity check.
+		if len(currentLeaves) != len(leaves)-len(delHashes) {
+			t.Fatalf("FuzzGetMissingPositions fail. Expected %d leaves but have %d in the pollard map",
+				len(leaves)-len(delHashes), len(currentLeaves))
+		}
+
+		// Randomly grab some leaves.
+		indexes := randomIndexes(len(currentLeaves), 2)
+		leafSubset := make([]hashAndPos, len(indexes))
+		for i := range leafSubset {
+			leafSubset[i] = currentLeaves[indexes[i]]
+		}
+
+		// Grab at least 1 leaf to leave out.
+		leaveOutCount := rand.Intn(len(leafSubset)-1) + 1
+		for leaveOutCount <= len(leafSubset)-1 && leaveOutCount < 1 {
+			leaveOutCount++
+		}
+		// Randomly select leaves to leave out.
+		leftOutLeaves := make([]hashAndPos, leaveOutCount)
+		for i := range leftOutLeaves {
+			// Randomly select a leaf to leave out.
+			hashIdx := rand.Intn(len(leafSubset) - 1)
+			leftOutLeaves[i] = leafSubset[hashIdx]
+
+			// Remove the selected leaf from the subset.
+			leafSubset = append(leafSubset[:hashIdx], leafSubset[hashIdx+1:]...)
+		}
+		hashes := make([]Hash, len(leafSubset))
+		for i := range hashes {
+			hashes[i] = leafSubset[i].hash
+		}
+
+		// Grab the proof of the leaves that we didn't leave out.
+		proof, err := p.Prove(hashes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Grab the positions of the leaves that we left out.
+		desiredPositions := make([]uint64, len(leftOutLeaves))
+		for i := range desiredPositions {
+			desiredPositions[i] = leftOutLeaves[i].pos
+		}
+
+		// Call GetMissingPositions and get all the positions that we need to prove desiredPositions.
+		missingPositions := GetMissingPositions(p.numLeaves, proof, desiredPositions)
+
+		// Create a new proof from missingPositions and verify to make sure it's correct.
+		newProof, newDelHashes, err := calcDelHashAndProof(&p, proof, missingPositions, desiredPositions, leftOutLeaves, leafSubset)
+		if err != nil {
+			t.Fatalf("FuzzGetMissingPositions fail. Error %v", err)
+		}
+		err = p.Verify(newDelHashes, newProof)
+		if err != nil {
+			t.Fatalf("FuzzGetMissingPositions fail: New proof failed to verify. error: %v", err)
+		}
+	})
+}

--- a/testdata/fuzz/FuzzGetMissingPositions/01c166e786e219b6deec1a8e5ea046e05c12b1899d89b840bd795bd3ef610fd7
+++ b/testdata/fuzz/FuzzGetMissingPositions/01c166e786e219b6deec1a8e5ea046e05c12b1899d89b840bd795bd3ef610fd7
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(47)
+uint32(1)
+int64(-146)

--- a/testdata/fuzz/FuzzGetMissingPositions/023ae135ec56f116c0f4e369c7107400d2604f23ec29c91021a4f5e46b022daa
+++ b/testdata/fuzz/FuzzGetMissingPositions/023ae135ec56f116c0f4e369c7107400d2604f23ec29c91021a4f5e46b022daa
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(32)
+uint32(0)
+int64(-83)

--- a/testdata/fuzz/FuzzGetMissingPositions/04312f074613cbe747957383671aea4b735700227abe10f9041afcdb3c13edeb
+++ b/testdata/fuzz/FuzzGetMissingPositions/04312f074613cbe747957383671aea4b735700227abe10f9041afcdb3c13edeb
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(140)
+uint32(82)
+int64(-80)

--- a/testdata/fuzz/FuzzGetMissingPositions/15ea06608dccf7ca0691dfb97f839c31a452e93ddd5474b374bc9f3ec88e5694
+++ b/testdata/fuzz/FuzzGetMissingPositions/15ea06608dccf7ca0691dfb97f839c31a452e93ddd5474b374bc9f3ec88e5694
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(6)
+uint32(2)
+int64(13)

--- a/testdata/fuzz/FuzzGetMissingPositions/1ca1c4816003fbc18e98c0d303d5715846e5042d0589138edcb6550033879e78
+++ b/testdata/fuzz/FuzzGetMissingPositions/1ca1c4816003fbc18e98c0d303d5715846e5042d0589138edcb6550033879e78
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(0)
+uint32(3)
+int64(-1)

--- a/testdata/fuzz/FuzzGetMissingPositions/3100b733d31ed5e6458dcdc2e5b5f2278a0e430d1746e8560aa888b91b6c59ea
+++ b/testdata/fuzz/FuzzGetMissingPositions/3100b733d31ed5e6458dcdc2e5b5f2278a0e430d1746e8560aa888b91b6c59ea
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(2)
+int64(-32)

--- a/testdata/fuzz/FuzzGetMissingPositions/53172a918f1b5cdfb5b97087d47e2549bbc38b8fc3d1f60db22eb6f75c4e62f8
+++ b/testdata/fuzz/FuzzGetMissingPositions/53172a918f1b5cdfb5b97087d47e2549bbc38b8fc3d1f60db22eb6f75c4e62f8
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(17)
+uint32(3)
+int64(86)

--- a/testdata/fuzz/FuzzGetMissingPositions/671581e4e04b2b5110cefe141709c0dddedd8a00bee09d210fa082b853c27525
+++ b/testdata/fuzz/FuzzGetMissingPositions/671581e4e04b2b5110cefe141709c0dddedd8a00bee09d210fa082b853c27525
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(16)
+uint32(2)
+int64(-35)

--- a/testdata/fuzz/FuzzGetMissingPositions/a58a50987de345c2c166708237bf6fec09e0803aa4bc9db3d4b0931cf81f12fa
+++ b/testdata/fuzz/FuzzGetMissingPositions/a58a50987de345c2c166708237bf6fec09e0803aa4bc9db3d4b0931cf81f12fa
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(6)
+uint32(3)
+int64(106)

--- a/testdata/fuzz/FuzzGetMissingPositions/c3bdf0cac21cec345d9668d1c5a87cb8c841d12cc3ab2d407c0f771466a9cd2c
+++ b/testdata/fuzz/FuzzGetMissingPositions/c3bdf0cac21cec345d9668d1c5a87cb8c841d12cc3ab2d407c0f771466a9cd2c
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(3)
+int64(17)


### PR DESCRIPTION
GetMissingPositions() provides functionality for calculating the
positions you're missing to prove additional targets. This is useful
for mempool transactions relay as this allows for the peer to only
ask for certain un-cached positions instead of the entire proof.

There isn't code for constructing a proof from the missing positions
yet.