### PR TITLE
prove: Add RemovePositions()

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -545,3 +545,185 @@ func GetMissingPositions(numLeaves uint64, proofTargets, desiredTargets []uint64
 
 	return desiredPositions
 }
+
+// hashSiblings hashes the parent hash of the given hnp and sibHash and then tries to find all
+// the siblings of the resulting parent
+func hashSiblings(proofHashes []hashAndPos, hnp hashAndPos, sibHash Hash, forestRows uint8) []hashAndPos {
+	// Calculate the parent hash and the position.
+	var hash Hash
+	if isLeftNiece(hnp.pos) {
+		hash = parentHash(hnp.hash, sibHash)
+	} else {
+		hash = parentHash(sibHash, hnp.hash)
+	}
+	pos := parent(hnp.pos, forestRows)
+	proofHashes = append(proofHashes, hashAndPos{hash, pos})
+
+	// Go through the proofHashes and look for siblings of the newly hashed parent.
+	// If we find the sibling, we'll hash with the sibling to get the parent until we
+	// no longer find siblings.
+	idx := slices.IndexFunc(proofHashes, func(hnp hashAndPos) bool { return hnp.pos == sibling(pos) })
+	for idx != -1 {
+		// Calculate the parent hash and the position.
+		if isLeftNiece(pos) {
+			hash = parentHash(hash, proofHashes[idx].hash)
+		} else {
+			hash = parentHash(proofHashes[idx].hash, hash)
+		}
+		pos = parent(pos, forestRows)
+
+		// Pop off the last appended proofHash and the sibling since
+		// we hashed up.
+		proofHashes = append(proofHashes[:len(proofHashes)-1], proofHashes[len(proofHashes):]...)
+		proofHashes = append(proofHashes[:idx], proofHashes[idx+1:]...)
+
+		// Append the newly created parent.
+		proofHashes = append(proofHashes, hashAndPos{hash, pos})
+
+		// Look for the sibling of the newly created parent.
+		idx = slices.IndexFunc(proofHashes, func(hnp hashAndPos) bool { return hnp.pos == sibling(pos) })
+	}
+
+	return proofHashes
+}
+
+// RemoveTargets removes the selected targets from the given proof.
+// NOTE The passed in proof MUST be a valid proof. There are no checks done so it is the caller's
+// responsibility to make sure that the proof is valid.
+func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets []uint64) Proof {
+	forestRows := treeRows(numLeaves)
+
+	// Copy targets to avoid mutating the original.
+	targets := make([]uint64, len(proof.Targets))
+	copy(targets, proof.Targets)
+	targetHashes := toHashAndPos(targets, delHashes)
+
+	// Calculate the positions of the proofs that we currently have.
+	sort.Slice(targets, func(a, b int) bool { return targets[a] < targets[b] })
+	havePositions, _ := proofPositions(targets, numLeaves, forestRows)
+	proofHashes := toHashAndPos(havePositions, proof.Proof)
+
+	// Merge the target hashes and proof hashes and sort. We do this as some targets may become
+	// a proof.
+	proofHashes = append(proofHashes, targetHashes...)
+	sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
+
+	// Remove the remTargets from the targets.
+	sort.Slice(remTargets, func(a, b int) bool { return remTargets[a] < remTargets[b] })
+	targets = subtractSortedSlice(targets, remTargets, uint64Cmp)
+
+	// Get rid of all the leftover targets from the proofs.
+	proofHashes = subtractSortedSlice(proofHashes, targets,
+		func(a hashAndPos, b uint64) int {
+			if a.pos < b {
+				return -1
+			} else if a.pos > b {
+				return 1
+			}
+			return 0
+		})
+	// Calculate all the subtrees that we're interested in. We'll use this to leave out positions
+	// that are not included in the subtrees here.
+	//
+	// Example: If we're only interested in subtree 0 (positions 00, 01, 02, 03), we'll leave
+	// out position 04 and 05.
+	//
+	// 12
+	// |-------\
+	// 08      09      10
+	// |---\   |---\   |---\
+	// 00  01  02  03  04  05  06
+	subTrees := []uint8{}
+	for _, target := range targets {
+		subTree, _, _, _ := detectOffset(target, numLeaves)
+
+		idx := slices.Index(subTrees, subTree)
+		if idx == -1 {
+			subTrees = append(subTrees, subTree)
+		}
+	}
+
+	// Take out proofs that are not in the subtrees our new targets are located in.
+	for i := 0; i < len(proofHashes); i++ {
+		proof := proofHashes[i]
+		subTree, _, _, _ := detectOffset(proof.pos, numLeaves)
+
+		if !slices.Contains(subTrees, subTree) {
+			idx := slices.IndexFunc(proofHashes, func(elem hashAndPos) bool { return elem.pos == proof.pos })
+			proofHashes = append(proofHashes[:idx], proofHashes[idx+1:]...)
+			i--
+		}
+	}
+
+	// These are the positions that we need to calculate the new targets after deletion.
+	wantPositions, calculateable := proofPositions(targets, numLeaves, forestRows)
+	wantPositions = append(wantPositions, calculateable...)
+	sort.Slice(wantPositions, func(a, b int) bool { return wantPositions[a] < wantPositions[b] })
+
+	// These are all the positions that want to get rid of.
+	removePositions, _ := proofPositions(remTargets, numLeaves, forestRows)
+	removePositions = append(removePositions, remTargets...)
+	sort.Slice(removePositions, func(a, b int) bool { return removePositions[a] < removePositions[b] })
+
+	// There are some positions we want that are included in the removePositions. Subtract those
+	// from removePositions because we need them.
+	removePositions = subtractSortedSlice(removePositions, wantPositions, uint64Cmp)
+
+	// Go through all the removePositions from the proof, hashing up as needed.
+	proofIdx := 0
+	for i := 0; i < len(removePositions); i++ {
+		if proofIdx >= len(proofHashes) {
+			break
+		}
+
+		proofHash := proofHashes[proofIdx]
+		removePosition := removePositions[i]
+
+		if removePosition == proofHash.pos {
+			// The proofs are always sorted. Look at the next or the previous proof and check for sibling-ness.
+			// Then we call hash siblings and hash up to get the required proof. This needs to be done because
+			// the deleted proof may hash up to a required calculate-able proof.
+			//
+			// Example:
+			// In this below tree, if the targets are [00, 04] and we're deleting 00, then we need to hash up to
+			// 12 when deleting 00 as 12 is a required proof for 04.
+			//
+			// 14
+			// |---------------\
+			// 12              13
+			// |-------\       |-------\
+			// 08      09      10      11
+			// |---\   |---\   |---\   |---\
+			// 00  01  02  03  04  05  06  07
+			if proofIdx < len(proofHashes)-1 && proofHashes[proofIdx+1].pos == rightSib(proofHash.pos) {
+				proofHashes = hashSiblings(proofHashes, proofHash, proofHashes[proofIdx+1].hash, forestRows)
+
+				proofHashes = append(proofHashes[:proofIdx], proofHashes[proofIdx+2:]...)
+			} else if proofIdx >= 1 && proofHashes[proofIdx-1].pos == leftSib(proofHash.pos) {
+				proofHashes = hashSiblings(proofHashes, proofHash, proofHashes[proofIdx-1].hash, forestRows)
+
+				proofHashes = append(proofHashes[:proofIdx-1], proofHashes[proofIdx+1:]...)
+				proofIdx-- // decrement since we're taking out an element from the left side.
+			} else {
+				// If there are no siblings present, just remove it.
+				proofHashes = append(proofHashes[:proofIdx], proofHashes[proofIdx+1:]...)
+			}
+
+			sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
+		} else if removePosition < proofHash.pos {
+			continue
+		} else {
+			proofIdx++
+			i--
+		}
+	}
+
+	// Extract only the hashes.
+	sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
+	hashes := make([]Hash, len(proofHashes))
+	for i := range hashes {
+		hashes[i] = proofHashes[i].hash
+	}
+
+	return Proof{targets, hashes}
+}

--- a/testdata/fuzz/FuzzRemoveTargets/02807a328b862070bbc09ce02ced5647513fc7e861d899abba9c906a6a0a80d3
+++ b/testdata/fuzz/FuzzRemoveTargets/02807a328b862070bbc09ce02ced5647513fc7e861d899abba9c906a6a0a80d3
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(29)
+uint32(5)
+int64(25)

--- a/testdata/fuzz/FuzzRemoveTargets/064b5ffb4f0fa0061017619d2d95ba0f9750dfa09dd361fd28aa2bb9c9373fc4
+++ b/testdata/fuzz/FuzzRemoveTargets/064b5ffb4f0fa0061017619d2d95ba0f9750dfa09dd361fd28aa2bb9c9373fc4
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(13)
+uint32(0)
+int64(72)

--- a/testdata/fuzz/FuzzRemoveTargets/1149ba4e20610722d3113ba26ca74d3970b8806cdfeb45069c535d78564a86cd
+++ b/testdata/fuzz/FuzzRemoveTargets/1149ba4e20610722d3113ba26ca74d3970b8806cdfeb45069c535d78564a86cd
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(23)
+uint32(9)
+int64(65)

--- a/testdata/fuzz/FuzzRemoveTargets/1bd90df45f925e348802449d6c30202279111b12f74486b93570d6b7bb08db22
+++ b/testdata/fuzz/FuzzRemoveTargets/1bd90df45f925e348802449d6c30202279111b12f74486b93570d6b7bb08db22
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(25)
+uint32(4)
+int64(130)

--- a/testdata/fuzz/FuzzRemoveTargets/1c28f8721c3628be29f55f4e02aed08ed3df1e3bc21fcc2cdd38a82b8bbed2ce
+++ b/testdata/fuzz/FuzzRemoveTargets/1c28f8721c3628be29f55f4e02aed08ed3df1e3bc21fcc2cdd38a82b8bbed2ce
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(31)
+uint32(1)
+int64(-70)

--- a/testdata/fuzz/FuzzRemoveTargets/4c3660f5945baa40787d7f4f7680021bfcc685e0e85ef6cae2a302363136e3ec
+++ b/testdata/fuzz/FuzzRemoveTargets/4c3660f5945baa40787d7f4f7680021bfcc685e0e85ef6cae2a302363136e3ec
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(27)
+uint32(0)
+int64(23)

--- a/testdata/fuzz/FuzzRemoveTargets/65b55b79ec6de3f940c4b1662c9efa17b37991cb329bc96ad54ea6fb114f1fb3
+++ b/testdata/fuzz/FuzzRemoveTargets/65b55b79ec6de3f940c4b1662c9efa17b37991cb329bc96ad54ea6fb114f1fb3
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(89)
+uint32(3)
+int64(39)

--- a/testdata/fuzz/FuzzRemoveTargets/6a123fd1890f7ed3d3e540f8b9848deb1652df51cc55749730ed66dac7b7790e
+++ b/testdata/fuzz/FuzzRemoveTargets/6a123fd1890f7ed3d3e540f8b9848deb1652df51cc55749730ed66dac7b7790e
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(4)
+int64(110)

--- a/testdata/fuzz/FuzzRemoveTargets/7e892cb72866a738c298d1a401467be85654010b6cabd5b5e01c1e821cd86229
+++ b/testdata/fuzz/FuzzRemoveTargets/7e892cb72866a738c298d1a401467be85654010b6cabd5b5e01c1e821cd86229
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(27)
+uint32(0)
+int64(32)

--- a/testdata/fuzz/FuzzRemoveTargets/7f92a33e12d393b6adecc68fd63f8afc4704d925c20fa99977f4565643d2e71d
+++ b/testdata/fuzz/FuzzRemoveTargets/7f92a33e12d393b6adecc68fd63f8afc4704d925c20fa99977f4565643d2e71d
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(32)
+uint32(7)
+int64(245)

--- a/testdata/fuzz/FuzzRemoveTargets/8b6d2457ef9cef2290ee1ff76cf541e2db31b485519b2d6164e8e76b29c56e95
+++ b/testdata/fuzz/FuzzRemoveTargets/8b6d2457ef9cef2290ee1ff76cf541e2db31b485519b2d6164e8e76b29c56e95
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(31)
+uint32(2)
+int64(12)

--- a/testdata/fuzz/FuzzRemoveTargets/8ec334e86aaf583140ef3c8cf3439bde7023399e642ce3f5c4e2d17d262d0833
+++ b/testdata/fuzz/FuzzRemoveTargets/8ec334e86aaf583140ef3c8cf3439bde7023399e642ce3f5c4e2d17d262d0833
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(60)
+uint32(1)
+int64(-108)

--- a/testdata/fuzz/FuzzRemoveTargets/ad1e3fed9ba9f1ffd0c40e77c8719ae6ccd5d9c043a7757e42351b3a97eaa6c9
+++ b/testdata/fuzz/FuzzRemoveTargets/ad1e3fed9ba9f1ffd0c40e77c8719ae6ccd5d9c043a7757e42351b3a97eaa6c9
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(27)
+uint32(0)
+int64(47)

--- a/testdata/fuzz/FuzzRemoveTargets/b055c66716cb661b4b7fc35403f6b7b4081162809738d1bd0fbc854af302d11b
+++ b/testdata/fuzz/FuzzRemoveTargets/b055c66716cb661b4b7fc35403f6b7b4081162809738d1bd0fbc854af302d11b
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(20)
+uint32(5)
+int64(10)

--- a/testdata/fuzz/FuzzRemoveTargets/c40751f3d2fb129f019254be8f60f8f54ef81a8164978474785460fbfcdda1e9
+++ b/testdata/fuzz/FuzzRemoveTargets/c40751f3d2fb129f019254be8f60f8f54ef81a8164978474785460fbfcdda1e9
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(79)
+uint32(2)
+int64(47)

--- a/testdata/fuzz/FuzzRemoveTargets/c40fd7bd756565ddd87b26798066184f3e971cdbe64aa4564dfd9bdbc501ad15
+++ b/testdata/fuzz/FuzzRemoveTargets/c40fd7bd756565ddd87b26798066184f3e971cdbe64aa4564dfd9bdbc501ad15
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(30)
+uint32(0)
+int64(-184)

--- a/testdata/fuzz/FuzzRemoveTargets/cbcc67976d106726f1e9f980baca05c32c7a40ca04d2789fc223e1a48514ccab
+++ b/testdata/fuzz/FuzzRemoveTargets/cbcc67976d106726f1e9f980baca05c32c7a40ca04d2789fc223e1a48514ccab
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(16)
+uint32(9)
+int64(12)


### PR DESCRIPTION
RemovePositions() allows for the removal of desired slice of positions
from the proof. This is useful for un-caching of leaves after they're
deleted. For Bitcoin wallets, this will be useful when deleting stxos
from the cached proof.