### PR TITLE
prove: Return delHashes in RemoveTargets()

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -594,30 +594,45 @@ func hashSiblings(proofHashes []hashAndPos, hnp hashAndPos, sibHash Hash, forest
 // RemoveTargets removes the selected targets from the given proof.
 // NOTE The passed in proof MUST be a valid proof. There are no checks done so it is the caller's
 // responsibility to make sure that the proof is valid.
-func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets []uint64) Proof {
+func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets []uint64) ([]Hash, Proof) {
 	forestRows := treeRows(numLeaves)
 
 	// Copy targets to avoid mutating the original.
 	targets := make([]uint64, len(proof.Targets))
 	copy(targets, proof.Targets)
-	targetHashes := toHashAndPos(targets, delHashes)
+	targetHashesWithPos := toHashAndPos(targets, delHashes)
 
 	// Calculate the positions of the proofs that we currently have.
 	sort.Slice(targets, func(a, b int) bool { return targets[a] < targets[b] })
 	havePositions, _ := proofPositions(targets, numLeaves, forestRows)
-	proofHashes := toHashAndPos(havePositions, proof.Proof)
+	proofHashesWithPos := toHashAndPos(havePositions, proof.Proof)
 
 	// Merge the target hashes and proof hashes and sort. We do this as some targets may become
 	// a proof.
-	proofHashes = append(proofHashes, targetHashes...)
-	sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
+	proofHashesWithPos = mergeSortedSlicesFunc(proofHashesWithPos, targetHashesWithPos, hashAndPosCmp)
 
 	// Remove the remTargets from the targets.
-	sort.Slice(remTargets, func(a, b int) bool { return remTargets[a] < remTargets[b] })
-	targets = subtractSortedSlice(targets, remTargets, uint64Cmp)
+	targetHashesWithPos = subtractSortedSlice(targetHashesWithPos, remTargets,
+		func(a hashAndPos, b uint64) int {
+			if a.pos < b {
+				return -1
+			} else if a.pos > b {
+				return 1
+			}
+			return 0
+		})
+	// Extract hashes and positions.
+	targetHashes := make([]Hash, len(targetHashesWithPos))
+	for i := range targetHashes {
+		targetHashes[i] = targetHashesWithPos[i].hash
+	}
+	targets = make([]uint64, len(targetHashesWithPos))
+	for i := range targets {
+		targets[i] = targetHashesWithPos[i].pos
+	}
 
 	// Get rid of all the leftover targets from the proofs.
-	proofHashes = subtractSortedSlice(proofHashes, targets,
+	proofHashesWithPos = subtractSortedSlice(proofHashesWithPos, targets,
 		func(a hashAndPos, b uint64) int {
 			if a.pos < b {
 				return -1
@@ -648,26 +663,24 @@ func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets [
 	}
 
 	// Take out proofs that are not in the subtrees our new targets are located in.
-	for i := 0; i < len(proofHashes); i++ {
-		proof := proofHashes[i]
+	for i := 0; i < len(proofHashesWithPos); i++ {
+		proof := proofHashesWithPos[i]
 		subTree, _, _, _ := detectOffset(proof.pos, numLeaves)
 
 		if !slices.Contains(subTrees, subTree) {
-			idx := slices.IndexFunc(proofHashes, func(elem hashAndPos) bool { return elem.pos == proof.pos })
-			proofHashes = append(proofHashes[:idx], proofHashes[idx+1:]...)
+			idx := slices.IndexFunc(proofHashesWithPos, func(elem hashAndPos) bool { return elem.pos == proof.pos })
+			proofHashesWithPos = append(proofHashesWithPos[:idx], proofHashesWithPos[idx+1:]...)
 			i--
 		}
 	}
 
 	// These are the positions that we need to calculate the new targets after deletion.
 	wantPositions, calculateable := proofPositions(targets, numLeaves, forestRows)
-	wantPositions = append(wantPositions, calculateable...)
-	sort.Slice(wantPositions, func(a, b int) bool { return wantPositions[a] < wantPositions[b] })
+	wantPositions = mergeSortedSlicesFunc(wantPositions, calculateable, uint64Cmp)
 
 	// These are all the positions that want to get rid of.
 	removePositions, _ := proofPositions(remTargets, numLeaves, forestRows)
-	removePositions = append(removePositions, remTargets...)
-	sort.Slice(removePositions, func(a, b int) bool { return removePositions[a] < removePositions[b] })
+	removePositions = mergeSortedSlicesFunc(removePositions, remTargets, uint64Cmp)
 
 	// There are some positions we want that are included in the removePositions. Subtract those
 	// from removePositions because we need them.
@@ -676,11 +689,11 @@ func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets [
 	// Go through all the removePositions from the proof, hashing up as needed.
 	proofIdx := 0
 	for i := 0; i < len(removePositions); i++ {
-		if proofIdx >= len(proofHashes) {
+		if proofIdx >= len(proofHashesWithPos) {
 			break
 		}
 
-		proofHash := proofHashes[proofIdx]
+		proofHash := proofHashesWithPos[proofIdx]
 		removePosition := removePositions[i]
 
 		if removePosition == proofHash.pos {
@@ -699,21 +712,21 @@ func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets [
 			// 08      09      10      11
 			// |---\   |---\   |---\   |---\
 			// 00  01  02  03  04  05  06  07
-			if proofIdx < len(proofHashes)-1 && proofHashes[proofIdx+1].pos == rightSib(proofHash.pos) {
-				proofHashes = hashSiblings(proofHashes, proofHash, proofHashes[proofIdx+1].hash, forestRows)
+			if proofIdx < len(proofHashesWithPos)-1 && proofHashesWithPos[proofIdx+1].pos == rightSib(proofHash.pos) {
+				proofHashesWithPos = hashSiblings(proofHashesWithPos, proofHash, proofHashesWithPos[proofIdx+1].hash, forestRows)
 
-				proofHashes = append(proofHashes[:proofIdx], proofHashes[proofIdx+2:]...)
-			} else if proofIdx >= 1 && proofHashes[proofIdx-1].pos == leftSib(proofHash.pos) {
-				proofHashes = hashSiblings(proofHashes, proofHash, proofHashes[proofIdx-1].hash, forestRows)
+				proofHashesWithPos = append(proofHashesWithPos[:proofIdx], proofHashesWithPos[proofIdx+2:]...)
+			} else if proofIdx >= 1 && proofHashesWithPos[proofIdx-1].pos == leftSib(proofHash.pos) {
+				proofHashesWithPos = hashSiblings(proofHashesWithPos, proofHash, proofHashesWithPos[proofIdx-1].hash, forestRows)
 
-				proofHashes = append(proofHashes[:proofIdx-1], proofHashes[proofIdx+1:]...)
+				proofHashesWithPos = append(proofHashesWithPos[:proofIdx-1], proofHashesWithPos[proofIdx+1:]...)
 				proofIdx-- // decrement since we're taking out an element from the left side.
 			} else {
 				// If there are no siblings present, just remove it.
-				proofHashes = append(proofHashes[:proofIdx], proofHashes[proofIdx+1:]...)
+				proofHashesWithPos = append(proofHashesWithPos[:proofIdx], proofHashesWithPos[proofIdx+1:]...)
 			}
 
-			sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
+			sort.Slice(proofHashesWithPos, func(a, b int) bool { return proofHashesWithPos[a].pos < proofHashesWithPos[b].pos })
 		} else if removePosition < proofHash.pos {
 			continue
 		} else {
@@ -723,11 +736,11 @@ func RemoveTargets(numLeaves uint64, delHashes []Hash, proof Proof, remTargets [
 	}
 
 	// Extract only the hashes.
-	sort.Slice(proofHashes, func(a, b int) bool { return proofHashes[a].pos < proofHashes[b].pos })
-	hashes := make([]Hash, len(proofHashes))
-	for i := range hashes {
-		hashes[i] = proofHashes[i].hash
+	sort.Slice(proofHashesWithPos, func(a, b int) bool { return proofHashesWithPos[a].pos < proofHashesWithPos[b].pos })
+	proofHashes := make([]Hash, len(proofHashesWithPos))
+	for i := range proofHashes {
+		proofHashes[i] = proofHashesWithPos[i].hash
 	}
 
-	return Proof{targets, hashes}
+	return targetHashes, Proof{targets, proofHashes}
 }

--- a/prove.go
+++ b/prove.go
@@ -238,10 +238,14 @@ func mergeSortedSlicesFunc[E any](a, b []E, cmp func(E, E) int) (c []E) {
 
 	// shortcuts:
 	if maxa == 0 {
-		return b
+		c = make([]E, maxb)
+		copy(c, b)
+		return c
 	}
 	if maxb == 0 {
-		return a
+		c = make([]E, maxa)
+		copy(c, a)
+		return c
 	}
 
 	// make it (potentially) too long and truncate later

--- a/prove_test.go
+++ b/prove_test.go
@@ -305,15 +305,7 @@ func FuzzRemoveTargets(f *testing.F) {
 		}
 
 		// Delete the targets from the proof and verify the modified proof.
-		newproof := RemoveTargets(p.numLeaves, leafHashes, proof, positions)
-		newDelHashes := make([]Hash, len(newproof.Targets))
-		for i := range newDelHashes {
-			newDelHashes[i] = p.getHash(newproof.Targets[i])
-			if newDelHashes[i] == empty {
-				t.Fatalf("FuzzRemoveTargets fail: Couldn't grab the hash "+
-					"for target %d", newproof.Targets[i])
-			}
-		}
+		newDelHashes, newproof := RemoveTargets(p.numLeaves, leafHashes, proof, positions)
 
 		err = p.Verify(newDelHashes, newproof)
 		if err != nil {


### PR DESCRIPTION
The responsibility of removing the deleted hashes was on the caller
since RemoveTargets() would only remove the targets from the proof.
RemoveTargets() has enough information to also return the modified
delHashes so the function signature is changed to do so.