### PR TITLE
prove: Add UpdateProofRemove

### DIFF
--- a/testdata/fuzz/FuzzUpdateProofRemove/01298cc488ff878b0ac18a3ed9f770f218acdcfac78a886d2df3f04e54aaf717
+++ b/testdata/fuzz/FuzzUpdateProofRemove/01298cc488ff878b0ac18a3ed9f770f218acdcfac78a886d2df3f04e54aaf717
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(46)
+uint32(2)
+int64(-159)

--- a/testdata/fuzz/FuzzUpdateProofRemove/01767920f4491ac9b1449930b186669c1651decaf56042734fe3035f752b7f02
+++ b/testdata/fuzz/FuzzUpdateProofRemove/01767920f4491ac9b1449930b186669c1651decaf56042734fe3035f752b7f02
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(28)
+uint32(1)
+int64(-28)

--- a/testdata/fuzz/FuzzUpdateProofRemove/018d9d4abb09df7b7fa66d447312a2f8ec2b6bf86b36b2402cba4747349022b0
+++ b/testdata/fuzz/FuzzUpdateProofRemove/018d9d4abb09df7b7fa66d447312a2f8ec2b6bf86b36b2402cba4747349022b0
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(0)
+int64(55)

--- a/testdata/fuzz/FuzzUpdateProofRemove/07198aada44c542dae10710ccd59419e2ae3a7ab0e2021e457f423daff5d0c3e
+++ b/testdata/fuzz/FuzzUpdateProofRemove/07198aada44c542dae10710ccd59419e2ae3a7ab0e2021e457f423daff5d0c3e
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(2)
+int64(-30)

--- a/testdata/fuzz/FuzzUpdateProofRemove/9228179161ad9e9b7216e3b7ccf15bcaced8fe9b7e98e930cb6cc1c05d41a0fe
+++ b/testdata/fuzz/FuzzUpdateProofRemove/9228179161ad9e9b7216e3b7ccf15bcaced8fe9b7e98e930cb6cc1c05d41a0fe
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(83)
+uint32(2)
+int64(12)

--- a/testdata/fuzz/FuzzUpdateProofRemove/975b2b858339762e6373e9de37e134dedd7ab22372f5ecaefb175ce236f64161
+++ b/testdata/fuzz/FuzzUpdateProofRemove/975b2b858339762e6373e9de37e134dedd7ab22372f5ecaefb175ce236f64161
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(5)
+uint32(1)
+int64(47)

--- a/testdata/fuzz/FuzzUpdateProofRemove/d0b4fb38fd06de873da4fc047233d9b05cf6da02494fac8414ceb7e219a502c2
+++ b/testdata/fuzz/FuzzUpdateProofRemove/d0b4fb38fd06de873da4fc047233d9b05cf6da02494fac8414ceb7e219a502c2
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(0)
+int64(12)

--- a/testdata/fuzz/FuzzUpdateProofRemove/ee3cbb0fe479ecbd38e2f06fd1c354d1a2b4ecfefb339bd5c452a932e48a18b4
+++ b/testdata/fuzz/FuzzUpdateProofRemove/ee3cbb0fe479ecbd38e2f06fd1c354d1a2b4ecfefb339bd5c452a932e48a18b4
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(2)
+int64(0)

--- a/testdata/fuzz/FuzzUpdateProofRemove/f1bdbd8604c0c92bd55b6c3c0f8d07ed7ac8aaeb91b648e7a31241269f1857b4
+++ b/testdata/fuzz/FuzzUpdateProofRemove/f1bdbd8604c0c92bd55b6c3c0f8d07ed7ac8aaeb91b648e7a31241269f1857b4
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(2)
+int64(12)


### PR DESCRIPTION
UpdateProofRemove provides functionality for updating the cached proof
with a block proof. The returned hashes and proof will be proving the
targets that were not deleted from by the block proof.

This functionality is useful for Bitcoin wallets and Bitcoin nodes that
maintain a mempool.