### PR TITLE
utils: isAncestor bug fix

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -107,6 +107,9 @@ func isRootPosition(position, numLeaves uint64, forestRows uint8) bool {
 //
 // In the above tree, 12 is an ancestor of 00. 13 is not an ancestor of 00.
 func isAncestor(higherPos, lowerPos uint64, forestRows uint8) bool {
+	if higherPos == lowerPos {
+		return false
+	}
 	lowerRow := detectRow(lowerPos, forestRows)
 	higherRow := detectRow(higherPos, forestRows)
 


### PR DESCRIPTION
Giving the same positions in isAncestor would return true. This *can*
result in bugs for some edge cases as if you attempted to call
calcNextPosition after checking for ancestor-ness with isAncestor, its
behavior would be undefined since the ancestor check is incorrect.