### PR TITLE
prove: Add UpdateProofAdd

### DIFF
--- a/testdata/fuzz/FuzzUpdateProofAdd/0d82cc561b6b4f508eab1125bde23e3f751e4923f335b6b51d09bbcf57450ee9
+++ b/testdata/fuzz/FuzzUpdateProofAdd/0d82cc561b6b4f508eab1125bde23e3f751e4923f335b6b51d09bbcf57450ee9
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(7)
+uint32(3)
+uint32(7)
+int64(195)

--- a/testdata/fuzz/FuzzUpdateProofAdd/35230858d13aa8ffe466a6258e70e282cc54b2468e09d75b6d2b95ac00a08da3
+++ b/testdata/fuzz/FuzzUpdateProofAdd/35230858d13aa8ffe466a6258e70e282cc54b2468e09d75b6d2b95ac00a08da3
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(15)
+uint32(8)
+uint32(1)
+int64(-73)

--- a/testdata/fuzz/FuzzUpdateProofAdd/3d97223d357ea343991fae926e700828b4ae6134c9772f95f52b7aa22c9c7efd
+++ b/testdata/fuzz/FuzzUpdateProofAdd/3d97223d357ea343991fae926e700828b4ae6134c9772f95f52b7aa22c9c7efd
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(23)
+uint32(16)
+uint32(6)
+int64(-49)

--- a/testdata/fuzz/FuzzUpdateProofAdd/408890dd4dc94028f06996744c8edb4a418ae68fcb345979e1c98f5a8666b798
+++ b/testdata/fuzz/FuzzUpdateProofAdd/408890dd4dc94028f06996744c8edb4a418ae68fcb345979e1c98f5a8666b798
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(18)
+uint32(0)
+uint32(1)
+int64(-60)

--- a/testdata/fuzz/FuzzUpdateProofAdd/814dea3693871172e625be3fa95a58c30ce320f6f31611e66e535159ad99f3ca
+++ b/testdata/fuzz/FuzzUpdateProofAdd/814dea3693871172e625be3fa95a58c30ce320f6f31611e66e535159ad99f3ca
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(15)
+uint32(12)
+uint32(126)
+int64(-23)

--- a/testdata/fuzz/FuzzUpdateProofAdd/922490e8cf312f31194c1ddfba3860ebce13eee0128efb8735aadd842a263ee3
+++ b/testdata/fuzz/FuzzUpdateProofAdd/922490e8cf312f31194c1ddfba3860ebce13eee0128efb8735aadd842a263ee3
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(16)
+uint32(2)
+uint32(0)
+int64(12)

--- a/testdata/fuzz/FuzzUpdateProofAdd/a372ba6f0a8a927ccb5a8baa799771f336563a670a9d101bc1a244bb59f719d2
+++ b/testdata/fuzz/FuzzUpdateProofAdd/a372ba6f0a8a927ccb5a8baa799771f336563a670a9d101bc1a244bb59f719d2
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(19)
+uint32(2)
+uint32(1)
+int64(45)

--- a/testdata/fuzz/FuzzUpdateProofAdd/b9ccb15d9585a38e612e3507caf91bb6cbf0e869f5842ef5430eb1d7afd428a6
+++ b/testdata/fuzz/FuzzUpdateProofAdd/b9ccb15d9585a38e612e3507caf91bb6cbf0e869f5842ef5430eb1d7afd428a6
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(90)
+uint32(85)
+uint32(16)
+int64(-37)

--- a/testdata/fuzz/FuzzUpdateProofAdd/bc69874923e2d32bc9ac0362a907969d627d245b3d8f72eb6baf5328715c9f83
+++ b/testdata/fuzz/FuzzUpdateProofAdd/bc69874923e2d32bc9ac0362a907969d627d245b3d8f72eb6baf5328715c9f83
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(15)
+uint32(12)
+uint32(7)
+int64(-149)

--- a/testdata/fuzz/FuzzUpdateProofAdd/d74d552aff1588f4e74f5b159dad29d1445ae608b2abe0ebd2729f254f9d9310
+++ b/testdata/fuzz/FuzzUpdateProofAdd/d74d552aff1588f4e74f5b159dad29d1445ae608b2abe0ebd2729f254f9d9310
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint32(7)
+uint32(62)
+uint32(101)
+int64(12)


### PR DESCRIPTION
UpdateProofAdd modifies the given cached proof to add the extra
necessary hashes after new leaves have been added to the accumulator.

Use cases for this are for wallets and mempool where the proof for
existing cached leaves will need to be modified when a block or tx comes
in.