### PR TITLE
accumulator: Export pollard fields

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -11,11 +11,11 @@ import (
 // Pollard is a representation of the utreexo forest using a collection of
 // binary trees. It may or may not contain the entire set.
 type Pollard struct {
-	// nodeMap maps hashes to polNodes. Used during proving individual elements
+	// NodeMap maps hashes to polNodes. Used during proving individual elements
 	// in the accumulator.
-	nodeMap map[miniHash]*polNode
+	NodeMap map[miniHash]*polNode
 
-	// roots are the roots of each tree in the forest.
+	// Roots are the roots of each tree in the forest.
 	//
 	// NOTE: Since roots don't have nieces, they point to children.
 	// In the below tree, 06 is the root and it points to its children,
@@ -45,7 +45,7 @@ type Pollard struct {
 // for all elements, set full to true.
 func NewAccumulator(full bool) Pollard {
 	var p Pollard
-	p.nodeMap = make(map[miniHash]*polNode)
+	p.NodeMap = make(map[miniHash]*polNode)
 	p.full = full
 
 	return p
@@ -88,7 +88,7 @@ func (p *Pollard) add(adds []Leaf) {
 
 		// Add the hash to the map if this node is supposed to be remembered.
 		if node.remember {
-			p.nodeMap[add.mini()] = node
+			p.NodeMap[add.mini()] = node
 		}
 
 		newRoot := p.calculateNewRoot(node)
@@ -201,7 +201,7 @@ func (p *Pollard) deleteRoot(del uint64) error {
 	}
 
 	// Delete from map.
-	delete(p.nodeMap, p.roots[tree].data.mini())
+	delete(p.NodeMap, p.roots[tree].data.mini())
 
 	if p.roots[tree].lNiece != nil {
 		p.roots[tree].lNiece.aunt = nil
@@ -254,14 +254,14 @@ func (p *Pollard) deleteSingle(del uint64) error {
 		delNode(fromNode)
 
 		// If the node was a leaf, update the map to point to the root.
-		_, found := p.nodeMap[toNode.data.mini()]
+		_, found := p.NodeMap[toNode.data.mini()]
 		if found {
-			p.nodeMap[toNode.data.mini()] = toNode
+			p.NodeMap[toNode.data.mini()] = toNode
 		}
 	}
 
 	// Delete the node from the map.
-	delete(p.nodeMap, fromNodeSib.data.mini())
+	delete(p.NodeMap, fromNodeSib.data.mini())
 	delNode(fromNodeSib)
 
 	// If to position is a root, there's no parent hash to be calculated so
@@ -301,7 +301,7 @@ func (p *Pollard) deleteSingle(del uint64) error {
 // deleteFromMap deletes the hashes passed in from the node map.
 func (p *Pollard) deleteFromMap(delHashes []Hash) {
 	for _, del := range delHashes {
-		delete(p.nodeMap, del.mini())
+		delete(p.NodeMap, del.mini())
 	}
 }
 
@@ -395,7 +395,7 @@ func (p *Pollard) undoSingleAdd() {
 			row = -1
 		}
 
-		delete(p.nodeMap, lowestRoot.data.mini())
+		delete(p.NodeMap, lowestRoot.data.mini())
 		delNode(lowestRoot)
 	}
 	p.numLeaves--
@@ -412,7 +412,7 @@ func (p *Pollard) undoDels(dels []uint64, delHashes []Hash) error {
 		pn := &polNode{data: delHashes[i], remember: p.full}
 		pnps[i] = nodeAndPos{pn, dels[i]}
 
-		p.nodeMap[delHashes[i].mini()] = pn
+		p.NodeMap[delHashes[i].mini()] = pn
 	}
 	sort.Slice(pnps, func(a, b int) bool { return pnps[a].pos < pnps[b].pos })
 
@@ -495,9 +495,9 @@ func (p *Pollard) undoSingleDel(node *polNode, pos uint64) error {
 
 		swapNieces(parent.lNiece, parent.rNiece)
 
-		_, found := p.nodeMap[sibling.data.mini()]
+		_, found := p.NodeMap[sibling.data.mini()]
 		if found {
-			p.nodeMap[sibling.data.mini()] = sibling
+			p.NodeMap[sibling.data.mini()] = sibling
 		}
 
 		return nil
@@ -673,9 +673,9 @@ func RestorePollardFrom(r io.Reader) (int64, *Pollard, error) {
 	}
 
 	// Sanity check.
-	if len(p.nodeMap) != int(p.numLeaves-p.numDels) {
+	if len(p.NodeMap) != int(p.numLeaves-p.numDels) {
 		err = fmt.Errorf("RestorePollard fail. Expect a total or %d "+
-			"leaves but only have %d leaves in the map", p.numLeaves-p.numDels, len(p.nodeMap))
+			"leaves but only have %d leaves in the map", p.numLeaves-p.numDels, len(p.NodeMap))
 		return totalBytes, nil, err
 	}
 
@@ -706,7 +706,7 @@ func (p *Pollard) readOne(n *polNode, r io.Reader) (int64, error) {
 	totalBytes += int64(readBytes)
 	if buf[0] == 1 {
 		if n.data != empty {
-			p.nodeMap[n.data.mini()] = n
+			p.NodeMap[n.data.mini()] = n
 		}
 	}
 

--- a/accumulator.go
+++ b/accumulator.go
@@ -35,18 +35,18 @@ type Pollard struct {
 	// NumDels is the number of all elements that were deleted from the accumulator.
 	NumDels uint64
 
-	// full indicates that this pollard will keep all the leaves in the accumulator.
-	// Only Pollards that have the full value set to true will be able to prove all
+	// Full indicates that this pollard will keep all the leaves in the accumulator.
+	// Only Pollards that have the Full value set to true will be able to prove all
 	// the elements.
-	full bool
+	Full bool
 }
 
 // NewAccumulator returns a initialized accumulator. To enable the generating proofs
-// for all elements, set full to true.
+// for all elements, set Full to true.
 func NewAccumulator(full bool) Pollard {
 	var p Pollard
 	p.NodeMap = make(map[miniHash]*polNode)
-	p.full = full
+	p.Full = full
 
 	return p
 }
@@ -79,10 +79,10 @@ func (p *Pollard) Modify(adds []Leaf, delHashes []Hash, origDels []uint64) error
 // add adds all the passed in leaves to the accumulator.
 func (p *Pollard) add(adds []Leaf) {
 	for _, add := range adds {
-		// Create a node from the hash. If the pollard is full, then remember
+		// Create a node from the hash. If the pollard is Full, then remember
 		// every node.
 		node := &polNode{data: add.Hash, remember: add.Remember}
-		if p.full {
+		if p.Full {
 			node.remember = true
 		}
 
@@ -148,7 +148,7 @@ func (p *Pollard) calculateNewRoot(node *polNode) *polNode {
 		nHash := parentHash(root.data, node.data)
 
 		newRoot := &polNode{data: nHash, lNiece: root, rNiece: node}
-		if p.full {
+		if p.Full {
 			newRoot.remember = true
 		}
 
@@ -333,12 +333,12 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 	for i, prevRoot := range prevRoots {
 		if prevRoot == empty {
 			if i >= len(p.Roots) {
-				p.Roots = append(p.Roots, &polNode{remember: p.full})
+				p.Roots = append(p.Roots, &polNode{remember: p.Full})
 			}
 			if p.Roots[i].data != empty {
 				p.Roots = append(p.Roots, nil)
 				copy(p.Roots[i+1:], p.Roots[i:])
-				p.Roots[i] = &polNode{data: prevRoot, remember: p.full}
+				p.Roots[i] = &polNode{data: prevRoot, remember: p.Full}
 			}
 		}
 	}
@@ -360,7 +360,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 				return err
 			}
 			if int(tree) == len(p.Roots) {
-				p.Roots = append(p.Roots, &polNode{data: empty, remember: p.full})
+				p.Roots = append(p.Roots, &polNode{data: empty, remember: p.Full})
 			}
 			if int(tree) > len(p.Roots) {
 				return fmt.Errorf("undoEmptyRoots error: calculated root index of %d "+
@@ -370,7 +370,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 			if p.Roots[tree].data != empty {
 				p.Roots = append(p.Roots, nil)
 				copy(p.Roots[tree+1:], p.Roots[tree:])
-				p.Roots[tree] = &polNode{data: empty, remember: p.full}
+				p.Roots[tree] = &polNode{data: empty, remember: p.Full}
 			}
 		}
 	}
@@ -409,7 +409,7 @@ func (p *Pollard) undoDels(dels []uint64, delHashes []Hash) error {
 
 	pnps := make([]nodeAndPos, len(dels))
 	for i := range dels {
-		pn := &polNode{data: delHashes[i], remember: p.full}
+		pn := &polNode{data: delHashes[i], remember: p.Full}
 		pnps[i] = nodeAndPos{pn, dels[i]}
 
 		p.NodeMap[delHashes[i].mini()] = pn
@@ -454,7 +454,7 @@ func (p *Pollard) undoSingleDel(node *polNode, pos uint64) error {
 	}
 
 	pHash := calculateParentHash(pos, node, sibling)
-	parent := &polNode{data: pHash, remember: p.full}
+	parent := &polNode{data: pHash, remember: p.Full}
 
 	// If the original parent of the deleted node is not a root.
 	if sibling.aunt != nil {

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func (p *Pollard) posMapSanity() error {
-	if uint64(len(p.nodeMap)) != p.numLeaves-p.numDels {
+	if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
 		err := fmt.Errorf("Have %d leaves in map but only %d leaves in total",
-			len(p.nodeMap), p.numLeaves-p.numDels)
+			len(p.NodeMap), p.numLeaves-p.numDels)
 		return err
 	}
 
-	for mHash, node := range p.nodeMap {
+	for mHash, node := range p.NodeMap {
 		if node == nil {
 			return fmt.Errorf("Node in nodemap is nil. Key: %s",
 				hex.EncodeToString(mHash[:]))
@@ -570,7 +570,7 @@ func FuzzModify(f *testing.F) {
 			t.Fatal(err)
 		}
 		beforeStr := p.String()
-		beforeMap := nodeMapToString(p.nodeMap)
+		beforeMap := nodeMapToString(p.NodeMap)
 
 		modifyLeaves, _, _ := getAddsAndDels(uint32(p.numLeaves), modifyAdds, 0)
 		err = p.Modify(modifyLeaves, delHashes, delTargets)
@@ -578,7 +578,7 @@ func FuzzModify(f *testing.F) {
 			t.Fatal(err)
 		}
 		afterStr := p.String()
-		afterMap := nodeMapToString(p.nodeMap)
+		afterMap := nodeMapToString(p.NodeMap)
 
 		err = p.checkHashes()
 		if err != nil {
@@ -681,10 +681,10 @@ func FuzzModifyChain(f *testing.F) {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.nodeMap)) != p.numLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
 				err := fmt.Errorf("FuzzModifyChain fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.nodeMap), p.numLeaves-p.numDels)
+					b, len(p.NodeMap), p.numLeaves-p.numDels)
 				t.Fatal(err)
 			}
 
@@ -738,7 +738,7 @@ func FuzzUndo(f *testing.F) {
 		beforeStr := p.String()
 
 		beforeRoots := p.GetRoots()
-		beforeMap := nodeMapToString(p.nodeMap)
+		beforeMap := nodeMapToString(p.NodeMap)
 
 		bp, err := p.Prove(dels)
 		if err != nil {
@@ -762,7 +762,7 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 		afterStr := p.String()
-		afterMap := nodeMapToString(p.nodeMap)
+		afterMap := nodeMapToString(p.NodeMap)
 
 		err = p.Undo(uint64(modifyAdds), bp.Targets, dels, beforeRoots)
 		if err != nil {
@@ -798,7 +798,7 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 		undoStr := p.String()
-		undoMap := nodeMapToString(p.nodeMap)
+		undoMap := nodeMapToString(p.NodeMap)
 
 		// Check that all the parent hashes are correct after the undo.
 		err = p.checkHashes()
@@ -806,7 +806,7 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		if uint64(len(p.nodeMap)) != p.numLeaves-p.numDels {
+		if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
 			startHashes := make([]Hash, len(leaves))
 			for i, leaf := range leaves {
 				startHashes[i] = leaf.Hash
@@ -828,7 +828,7 @@ func FuzzUndo(f *testing.F) {
 				"\nnodemap before modify:\n %s"+
 				"\nnodemap after modify:\n %s"+
 				"\nnodemap after undo:\n %s",
-				len(p.nodeMap), p.numLeaves-p.numDels,
+				len(p.NodeMap), p.numLeaves-p.numDels,
 				beforeStr,
 				afterStr,
 				undoStr,
@@ -872,7 +872,7 @@ func FuzzUndo(f *testing.F) {
 				printHashes(modifyHashes),
 				printHashes(dels),
 				bp.Targets,
-				nodeMapToString(p.nodeMap)))
+				nodeMapToString(p.NodeMap)))
 		}
 
 		afterRoots := p.GetRoots()
@@ -954,7 +954,7 @@ func FuzzUndoChain(f *testing.F) {
 			// We'll be comparing 3 things. Roots, nodeMap and leaf count.
 			beforeRoot := p.GetRoots()
 			beforeMap := make(map[miniHash]polNode)
-			for key, value := range p.nodeMap {
+			for key, value := range p.NodeMap {
 				beforeMap[key] = *value
 			}
 			beforeLeaves := p.numLeaves
@@ -987,14 +987,14 @@ func FuzzUndoChain(f *testing.F) {
 					t.Fatal(err)
 				}
 
-				if len(p.nodeMap) != len(beforeMap) {
+				if len(p.NodeMap) != len(beforeMap) {
 					err := fmt.Errorf("FuzzUndoChain fail at block %d, map length mismatch. "+
-						"before %d, after %d", b, len(beforeMap), len(p.nodeMap))
+						"before %d, after %d", b, len(beforeMap), len(p.NodeMap))
 					t.Fatal(err)
 				}
 
 				for key, value := range beforeMap {
-					node, found := p.nodeMap[key]
+					node, found := p.NodeMap[key]
 					if !found {
 						err := fmt.Errorf("FuzzUndoChain fail at block %d, hash %s not found after undo",
 							b, hex.EncodeToString(key[:]))
@@ -1100,7 +1100,7 @@ func FuzzWriteAndRead(f *testing.F) {
 		}
 
 		// Check that the node maps are equal.
-		err = compareNodeMap(p.nodeMap, newP.nodeMap)
+		err = compareNodeMap(p.NodeMap, newP.NodeMap)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func (p *Pollard) posMapSanity() error {
-	if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
+	if uint64(len(p.NodeMap)) != p.NumLeaves-p.NumDels {
 		err := fmt.Errorf("Have %d leaves in map but only %d leaves in total",
-			len(p.NodeMap), p.NumLeaves-p.numDels)
+			len(p.NodeMap), p.NumLeaves-p.NumDels)
 		return err
 	}
 
@@ -681,10 +681,10 @@ func FuzzModifyChain(f *testing.F) {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.NumLeaves-p.NumDels {
 				err := fmt.Errorf("FuzzModifyChain fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.NodeMap), p.NumLeaves-p.numDels)
+					b, len(p.NodeMap), p.NumLeaves-p.NumDels)
 				t.Fatal(err)
 			}
 
@@ -806,7 +806,7 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
+		if uint64(len(p.NodeMap)) != p.NumLeaves-p.NumDels {
 			startHashes := make([]Hash, len(leaves))
 			for i, leaf := range leaves {
 				startHashes[i] = leaf.Hash
@@ -828,7 +828,7 @@ func FuzzUndo(f *testing.F) {
 				"\nnodemap before modify:\n %s"+
 				"\nnodemap after modify:\n %s"+
 				"\nnodemap after undo:\n %s",
-				len(p.NodeMap), p.NumLeaves-p.numDels,
+				len(p.NodeMap), p.NumLeaves-p.NumDels,
 				beforeStr,
 				afterStr,
 				undoStr,

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -305,7 +305,7 @@ func checkHashes(node, sibling *polNode, p *Pollard) error {
 // checkHashes is a wrapper around the checkHashes function. Provides an easy function to
 // check that the pollard has correct hashes.
 func (p *Pollard) checkHashes() error {
-	for _, root := range p.roots {
+	for _, root := range p.Roots {
 		if root.lNiece != nil && root.rNiece != nil {
 			// First check the root hash.
 			calculatedHash := parentHash(root.lNiece.data, root.rNiece.data)
@@ -1122,10 +1122,10 @@ func FuzzWriteAndRead(f *testing.F) {
 		}
 
 		// Compare the roots.
-		for i, root := range p.roots {
-			if newP.roots[i].data != root.data {
+		for i, root := range p.Roots {
+			if newP.Roots[i].data != root.data {
 				t.Fatalf("FuzzReadAndWrite Fail. Roots don't equal.\nOrig roots:\n%s\nNew roots:\n%s\n",
-					printPolNodes(p.roots), printPolNodes(newP.roots))
+					printPolNodes(p.Roots), printPolNodes(newP.Roots))
 			}
 		}
 	})

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func (p *Pollard) posMapSanity() error {
-	if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
+	if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
 		err := fmt.Errorf("Have %d leaves in map but only %d leaves in total",
-			len(p.NodeMap), p.numLeaves-p.numDels)
+			len(p.NodeMap), p.NumLeaves-p.numDels)
 		return err
 	}
 
@@ -333,11 +333,11 @@ func (p *Pollard) checkHashes() error {
 // calculates its position. Returns an error if the position calculated does
 // not match the position used to fetch the node.
 func (p *Pollard) positionSanity() error {
-	totalRows := treeRows(p.numLeaves)
+	totalRows := treeRows(p.NumLeaves)
 
 	for row := uint8(0); row < totalRows; row++ {
 		pos := startPositionAtRow(row, totalRows)
-		maxPosAtRow, err := maxPositionAtRow(row, totalRows, p.numLeaves)
+		maxPosAtRow, err := maxPositionAtRow(row, totalRows, p.NumLeaves)
 		if err != nil {
 			return fmt.Errorf("positionSanity fail. Error %v", err)
 		}
@@ -471,7 +471,7 @@ func (s *simChain) NextBlock(numAdds uint32) ([]Leaf, []int32, []Hash) {
 // leaves to be deleted.
 //
 // NOTE if getAddsAndDels are called multiple times for the same pollard, pass in
-// p.numLeaves into getAddsAndDels after the pollard has been modified with the
+// p.NumLeaves into getAddsAndDels after the pollard has been modified with the
 // previous set of adds and deletions. The leaves genereated are not random and
 // are just the next leaf encoded to a 32 byte hash.
 func getAddsAndDels(currentLeaves, addCount, delCount uint32) ([]Leaf, []Hash, []uint64) {
@@ -564,7 +564,7 @@ func FuzzModify(f *testing.F) {
 		}
 
 		p := NewAccumulator(true)
-		leaves, delHashes, delTargets := getAddsAndDels(uint32(p.numLeaves), startLeaves, delCount)
+		leaves, delHashes, delTargets := getAddsAndDels(uint32(p.NumLeaves), startLeaves, delCount)
 		err := p.Modify(leaves, nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -572,7 +572,7 @@ func FuzzModify(f *testing.F) {
 		beforeStr := p.String()
 		beforeMap := nodeMapToString(p.NodeMap)
 
-		modifyLeaves, _, _ := getAddsAndDels(uint32(p.numLeaves), modifyAdds, 0)
+		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), modifyAdds, 0)
 		err = p.Modify(modifyLeaves, delHashes, delTargets)
 		if err != nil {
 			t.Fatal(err)
@@ -681,10 +681,10 @@ func FuzzModifyChain(f *testing.F) {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
 				err := fmt.Errorf("FuzzModifyChain fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.NodeMap), p.numLeaves-p.numDels)
+					b, len(p.NodeMap), p.NumLeaves-p.numDels)
 				t.Fatal(err)
 			}
 
@@ -729,7 +729,7 @@ func FuzzUndo(f *testing.F) {
 
 		// Create the starting off pollard.
 		p := NewAccumulator(true)
-		leaves, dels, _ := getAddsAndDels(uint32(p.numLeaves), uint32(startLeaves), uint32(delCount))
+		leaves, dels, _ := getAddsAndDels(uint32(p.NumLeaves), uint32(startLeaves), uint32(delCount))
 		err := p.Modify(leaves, nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -750,13 +750,13 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		if p.numLeaves != 1 && len(bp.Targets) != len(dels) {
+		if p.NumLeaves != 1 && len(bp.Targets) != len(dels) {
 			err := fmt.Errorf("Have %d targets but %d target hashes",
 				len(bp.Targets), len(dels))
 			t.Fatal(err)
 		}
 
-		modifyLeaves, _, _ := getAddsAndDels(uint32(p.numLeaves), uint32(modifyAdds), 0)
+		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), uint32(modifyAdds), 0)
 		err = p.Modify(modifyLeaves, dels, bp.Targets)
 		if err != nil {
 			t.Fatal(err)
@@ -806,7 +806,7 @@ func FuzzUndo(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
+		if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
 			startHashes := make([]Hash, len(leaves))
 			for i, leaf := range leaves {
 				startHashes[i] = leaf.Hash
@@ -828,7 +828,7 @@ func FuzzUndo(f *testing.F) {
 				"\nnodemap before modify:\n %s"+
 				"\nnodemap after modify:\n %s"+
 				"\nnodemap after undo:\n %s",
-				len(p.NodeMap), p.numLeaves-p.numDels,
+				len(p.NodeMap), p.NumLeaves-p.numDels,
 				beforeStr,
 				afterStr,
 				undoStr,
@@ -957,17 +957,17 @@ func FuzzUndoChain(f *testing.F) {
 			for key, value := range p.NodeMap {
 				beforeMap[key] = *value
 			}
-			beforeLeaves := p.numLeaves
+			beforeLeaves := p.NumLeaves
 
 			err = p.Modify(adds, delHashes, bp.Targets)
 			if err != nil {
 				t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 			}
 
-			if p.numLeaves-uint64(len(adds)) != beforeLeaves {
+			if p.NumLeaves-uint64(len(adds)) != beforeLeaves {
 				err := fmt.Errorf("FuzzUndoChain fail at block %d. "+
 					"Added %d leaves but have %d leaves after modify",
-					b, len(adds), p.numLeaves)
+					b, len(adds), p.NumLeaves)
 				t.Fatal(err)
 			}
 

--- a/polnode.go
+++ b/polnode.go
@@ -124,14 +124,14 @@ func (p *Pollard) getNode(pos uint64) (n, sibling, parent *polNode, err error) {
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if tree >= uint8(len(p.roots)) {
+	if tree >= uint8(len(p.Roots)) {
 		return nil, nil, nil, fmt.Errorf("getNode error: couldn't fetch %d, "+
 			"calculated root index of %d but only have %d roots",
-			pos, tree, len(p.roots))
+			pos, tree, len(p.Roots))
 	}
 
 	// Initialize.
-	n, sibling, parent = p.roots[tree], p.roots[tree], nil
+	n, sibling, parent = p.Roots[tree], p.Roots[tree], nil
 
 	// Go down the tree to find the node we're looking for.
 	for h := int(branchLen) - 1; h >= 0; h-- {
@@ -200,7 +200,7 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 	// Calculate which row the root is on.
 	rootRow := -1
 	// Start from the lowest root.
-	rootIdx := len(p.roots) - 1
+	rootIdx := len(p.Roots) - 1
 	for h := 0; h <= int(forestRows); h++ {
 		// Because every root represents a perfect tree of every leaf
 		// we ever added, each root position will be a power of 2.
@@ -210,7 +210,7 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 		if (p.numLeaves>>h)&1 == 1 {
 			// If we found the root, save the row to rootRow
 			// and return.
-			if p.roots[rootIdx].data == polNode.data {
+			if p.Roots[rootIdx].data == polNode.data {
 				rootRow = h
 				break
 			}

--- a/polnode.go
+++ b/polnode.go
@@ -116,11 +116,11 @@ func (p *Pollard) getNode(pos uint64) (n, sibling, parent *polNode, err error) {
 	// Tree is the root the position is located under.
 	// branchLen denotes how far down the root the position is.
 	// bits tell us if we should go down to the left child or the right child.
-	if pos >= maxPosition(treeRows(p.numLeaves)) {
+	if pos >= maxPosition(treeRows(p.NumLeaves)) {
 		return nil, nil, nil,
-			fmt.Errorf("Position %d does not exist in tree of %d leaves", pos, p.numLeaves)
+			fmt.Errorf("Position %d does not exist in tree of %d leaves", pos, p.NumLeaves)
 	}
-	tree, branchLen, bits, err := detectOffset(pos, p.numLeaves)
+	tree, branchLen, bits, err := detectOffset(pos, p.NumLeaves)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -195,7 +195,7 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 		}
 		rowsToTop++
 	}
-	forestRows := treeRows(p.numLeaves)
+	forestRows := treeRows(p.NumLeaves)
 
 	// Calculate which row the root is on.
 	rootRow := -1
@@ -205,9 +205,9 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 		// Because every root represents a perfect tree of every leaf
 		// we ever added, each root position will be a power of 2.
 		//
-		// Go through the bits of numLeaves. Every bit that is on
+		// Go through the bits of NumLeaves. Every bit that is on
 		// represents a root.
-		if (p.numLeaves>>h)&1 == 1 {
+		if (p.NumLeaves>>h)&1 == 1 {
 			// If we found the root, save the row to rootRow
 			// and return.
 			if p.Roots[rootIdx].data == polNode.data {
@@ -221,7 +221,7 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 	}
 
 	// Start from the root and work our way down the position that we want.
-	retPos := rootPosition(p.numLeaves, uint8(rootRow), forestRows)
+	retPos := rootPosition(p.NumLeaves, uint8(rootRow), forestRows)
 
 	for i := 0; i < rowsToTop; i++ {
 		isRight := uint64(1) << i

--- a/polnode_test.go
+++ b/polnode_test.go
@@ -75,7 +75,7 @@ func TestCalculatePosition(t *testing.T) {
 		}
 
 		for hash, pos := range test.expected {
-			node, found := p.nodeMap[hash.mini()]
+			node, found := p.NodeMap[hash.mini()]
 			if !found {
 				err := fmt.Errorf("TestCalculatePosition error: "+
 					"expected node with hash of %s not found",

--- a/prove.go
+++ b/prove.go
@@ -63,7 +63,7 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 
 	// Grab the positions of the hashes that are to be proven.
 	for i, wanted := range hashes {
-		node, ok := p.nodeMap[wanted.mini()]
+		node, ok := p.NodeMap[wanted.mini()]
 		if !ok {
 			return proof, fmt.Errorf("Prove error: hash %s not found",
 				hex.EncodeToString(wanted[:]))

--- a/prove.go
+++ b/prove.go
@@ -50,11 +50,11 @@ func (p *Proof) String() string {
 func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 	// No hashes to prove means that the proof is empty. An empty
 	// pollard also has an empty proof.
-	if len(hashes) == 0 || p.numLeaves == 0 {
+	if len(hashes) == 0 || p.NumLeaves == 0 {
 		return Proof{}, nil
 	}
 	// A Pollard with 1 leaf has no proof and only 1 target.
-	if p.numLeaves == 1 {
+	if p.NumLeaves == 1 {
 		return Proof{Targets: []uint64{0}}, nil
 	}
 
@@ -80,7 +80,7 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 	sort.Slice(sortedTargets, func(a, b int) bool { return sortedTargets[a] < sortedTargets[b] })
 
 	// Get the positions of all the hashes that are needed to prove the targets
-	proofPositions, _ := proofPositions(sortedTargets, p.numLeaves, treeRows(p.numLeaves))
+	proofPositions, _ := proofPositions(sortedTargets, p.NumLeaves, treeRows(p.NumLeaves))
 
 	// Fetch all the proofs from the accumulator.
 	proof.Proof = make([]Hash, len(proofPositions))
@@ -139,7 +139,7 @@ func (p *Pollard) Verify(delHashes []Hash, proof Proof) error {
 			len(proof.Targets), len(delHashes))
 	}
 
-	rootCandidates := calculateRoots(p.numLeaves, delHashes, proof)
+	rootCandidates := calculateRoots(p.NumLeaves, delHashes, proof)
 	if len(rootCandidates) == 0 {
 		return fmt.Errorf("Pollard.Verify fail. No roots calculated "+
 			"but have %d deletions", len(delHashes))

--- a/prove.go
+++ b/prove.go
@@ -146,18 +146,18 @@ func (p *Pollard) Verify(delHashes []Hash, proof Proof) error {
 	}
 
 	rootMatches := 0
-	for i := range p.roots {
+	for i := range p.Roots {
 		if len(rootCandidates) > rootMatches &&
-			p.roots[len(p.roots)-(i+1)].data == rootCandidates[rootMatches] {
+			p.Roots[len(p.Roots)-(i+1)].data == rootCandidates[rootMatches] {
 			rootMatches++
 		}
 	}
 	// Error out if all the rootCandidates do not have a corresponding
 	// polnode with the same hash.
 	if len(rootCandidates) != rootMatches {
-		rootHashes := make([]Hash, len(p.roots))
+		rootHashes := make([]Hash, len(p.Roots))
 		for i := range rootHashes {
-			rootHashes[i] = p.roots[i].data
+			rootHashes[i] = p.Roots[i].data
 		}
 		// The proof is invalid because some root candidates were not
 		// included in `roots`.

--- a/prove_test.go
+++ b/prove_test.go
@@ -757,8 +757,8 @@ func FuzzUpdateProofAdd(f *testing.F) {
 		for i, leaf := range addLeaves {
 			addHashes[i] = leaf.Hash
 		}
-		rootHashes := make([]Hash, len(p.roots))
-		for i, root := range p.roots {
+		rootHashes := make([]Hash, len(p.Roots))
+		for i, root := range p.Roots {
 			rootHashes[i] = root.data
 		}
 		proofBeforeStr := cachedProof.String()
@@ -843,9 +843,9 @@ func FuzzModifyProofChain(f *testing.F) {
 
 			// Update the proof with the deletions and additions that
 			// happen in this block.
-			rootHashes := make([]Hash, len(p.roots))
+			rootHashes := make([]Hash, len(p.Roots))
 			for i := range rootHashes {
-				rootHashes[i] = p.roots[i].data
+				rootHashes[i] = p.Roots[i].data
 			}
 			addHashes := make([]Hash, len(adds))
 			for i := range addHashes {

--- a/prove_test.go
+++ b/prove_test.go
@@ -954,10 +954,10 @@ func FuzzModifyProofChain(f *testing.F) {
 				t.Fatalf("FuzzModifyProof fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.NumLeaves-p.NumDels {
 				err := fmt.Errorf("FuzzModifyProof fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.NodeMap), p.NumLeaves-p.numDels)
+					b, len(p.NodeMap), p.NumLeaves-p.NumDels)
 				t.Fatal(err)
 			}
 		}

--- a/prove_test.go
+++ b/prove_test.go
@@ -67,14 +67,14 @@ func calcDelHashAndProof(p *Pollard, proof Proof, missingPositions, desiredPosit
 	}
 
 	// Attach positions to the proof hashes.
-	proofPos, _ := proofPositions(proof.Targets, p.numLeaves, treeRows(p.numLeaves))
+	proofPos, _ := proofPositions(proof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
 	currentHashes := toHashAndPos(proofPos, proof.Proof)
 	// Append the needed hashes to the proof.
 	currentHashes = append(currentHashes, neededHashes...)
 
 	// As new targets are added, we're able to calulate positions that we couldn't before. These positions
 	// may already exist as proofs. Remove these as duplicates are not expected during proof verification.
-	_, calculateables := proofPositions(desiredPositions, p.numLeaves, treeRows(p.numLeaves))
+	_, calculateables := proofPositions(desiredPositions, p.NumLeaves, treeRows(p.NumLeaves))
 	for _, cal := range calculateables {
 		idx := slices.IndexFunc(currentHashes, func(hnp hashAndPos) bool { return hnp.pos == cal })
 		if idx != -1 {
@@ -147,7 +147,7 @@ func FuzzGetMissingPositions(f *testing.F) {
 
 		// Create the starting off pollard.
 		p := NewAccumulator(true)
-		leaves, delHashes, delPos := getAddsAndDels(uint32(p.numLeaves), startLeaves, delCount)
+		leaves, delHashes, delPos := getAddsAndDels(uint32(p.NumLeaves), startLeaves, delCount)
 		err := p.Modify(leaves, nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -213,7 +213,7 @@ func FuzzGetMissingPositions(f *testing.F) {
 		}
 
 		// Call GetMissingPositions and get all the positions that we need to prove desiredPositions.
-		missingPositions := GetMissingPositions(p.numLeaves, proof.Targets, desiredPositions)
+		missingPositions := GetMissingPositions(p.NumLeaves, proof.Targets, desiredPositions)
 
 		// Create a new proof from missingPositions and verify to make sure it's correct.
 		newProof, newDelHashes, err := calcDelHashAndProof(&p, proof, missingPositions, desiredPositions, leftOutLeaves, leafSubset)
@@ -305,7 +305,7 @@ func FuzzRemoveTargets(f *testing.F) {
 		}
 
 		// Delete the targets from the proof and verify the modified proof.
-		newDelHashes, newproof := RemoveTargets(p.numLeaves, leafHashes, proof, positions)
+		newDelHashes, newproof := RemoveTargets(p.NumLeaves, leafHashes, proof, positions)
 
 		err = p.Verify(newDelHashes, newproof)
 		if err != nil {
@@ -398,7 +398,7 @@ func FuzzAddProof(f *testing.F) {
 		}
 
 		// Add the proof.
-		leafHashesC, proofC := AddProof(proofA, proofB, leafHashesA, leafHashesB, p.numLeaves)
+		leafHashesC, proofC := AddProof(proofA, proofB, leafHashesA, leafHashesB, p.NumLeaves)
 
 		// These are the targets that we want to prove.
 		sortedProofATargets := copySortedFunc(proofA.Targets, uint64Less)
@@ -501,9 +501,9 @@ func FuzzProofAfterDeletion(f *testing.F) {
 		}
 
 		// Delete the positions from the cached proof.
-		leafHashes, proof = proofAfterPartialDeletion(p.numLeaves, proof, leafHashes, positions)
+		leafHashes, proof = proofAfterPartialDeletion(p.NumLeaves, proof, leafHashes, positions)
 
-		proofPos, _ := proofPositions(proof.Targets, p.numLeaves, treeRows(p.numLeaves))
+		proofPos, _ := proofPositions(proof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
 		if len(proofPos) != len(proof.Proof) {
 			t.Fatalf("FuzzProofAfterDeletion Fail. Have %v proofs but want %v.\nPollard:\n%s\n",
 				printHashes(proof.Proof), proofPos, p.String())
@@ -635,7 +635,7 @@ func FuzzUpdateProofRemove(f *testing.F) {
 		cachedTargetsAndHash = subtractSortedSlice(cachedTargetsAndHash, blockDelTargetsAndHash, hashAndPosCmp)
 
 		// Update the cached proof with the block proof.
-		leafHashes, cachedProof = UpdateProofRemove(cachedProof, blockProof, leafHashes, blockDelHashes, p.numLeaves)
+		leafHashes, cachedProof = UpdateProofRemove(cachedProof, blockProof, leafHashes, blockDelHashes, p.NumLeaves)
 
 		// Modify the pollard.
 		err = p.Modify(nil, blockDelHashes, delPositions)
@@ -669,7 +669,7 @@ func FuzzUpdateProofRemove(f *testing.F) {
 				printHashes(expectedHashes), printHashes(leafHashes))
 		}
 
-		cachedProofPos, _ := proofPositions(cachedProof.Targets, p.numLeaves, treeRows(p.numLeaves))
+		cachedProofPos, _ := proofPositions(cachedProof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
 		if len(cachedProofPos) != len(cachedProof.Proof) {
 			t.Fatalf("FuzzUpdateProofRemove Fail. CachedProof hashes:\n%v\nbut want these positions:\n%v.\nPollard:\n%s\n",
 				printHashes(cachedProof.Proof), cachedProofPos, p.String())
@@ -750,7 +750,7 @@ func FuzzUpdateProofAdd(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		addLeaves, _, _ := getAddsAndDels(uint32(p.numLeaves), addCount, 0)
+		addLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), addCount, 0)
 
 		// Update the cached proof with the block proof.
 		addHashes := make([]Hash, len(addLeaves))
@@ -762,7 +762,7 @@ func FuzzUpdateProofAdd(f *testing.F) {
 			rootHashes[i] = root.data
 		}
 		proofBeforeStr := cachedProof.String()
-		cachedProof = UpdateProofAdd(cachedProof, addHashes, Stump{rootHashes, p.numLeaves})
+		cachedProof = UpdateProofAdd(cachedProof, addHashes, Stump{rootHashes, p.NumLeaves})
 
 		beforePollardStr := p.String()
 		// Modify the pollard.
@@ -851,7 +851,7 @@ func FuzzModifyProofChain(f *testing.F) {
 			for i := range addHashes {
 				addHashes[i] = adds[i].Hash
 			}
-			stump := Stump{rootHashes, p.numLeaves}
+			stump := Stump{rootHashes, p.NumLeaves}
 			cachedHashes, cachedProof, err = UpdateProof(
 				cachedProof, blockProof, cachedHashes, delHashes, addHashes, stump)
 			if err != nil {
@@ -924,7 +924,7 @@ func FuzzModifyProofChain(f *testing.F) {
 
 			// Add the new UTXOs to the proof.
 			cachedHashes, cachedProof = AddProof(cachedProof, newProofToCache,
-				cachedHashes, newHashesToCache, p.numLeaves)
+				cachedHashes, newHashesToCache, p.NumLeaves)
 			// Sanity check that the new cached proof verifies.
 			err = p.Verify(cachedHashes, cachedProof)
 			if err != nil {
@@ -954,10 +954,10 @@ func FuzzModifyProofChain(f *testing.F) {
 				t.Fatalf("FuzzModifyProof fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.NumLeaves-p.numDels {
 				err := fmt.Errorf("FuzzModifyProof fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.NodeMap), p.numLeaves-p.numDels)
+					b, len(p.NodeMap), p.NumLeaves-p.numDels)
 				t.Fatal(err)
 			}
 		}

--- a/prove_test.go
+++ b/prove_test.go
@@ -159,7 +159,7 @@ func FuzzGetMissingPositions(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -268,7 +268,7 @@ func FuzzRemoveTargets(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -357,7 +357,7 @@ func FuzzAddProof(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -465,7 +465,7 @@ func FuzzProofAfterDeletion(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -574,7 +574,7 @@ func FuzzUpdateProofRemove(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves)-len(delHashes))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -726,7 +726,7 @@ func FuzzUpdateProofAdd(f *testing.F) {
 
 		// Grab the current leaves that exist in the accumulator.
 		currentLeaves := make([]hashAndPos, 0, len(leaves))
-		for _, node := range p.nodeMap {
+		for _, node := range p.NodeMap {
 			currentLeaves = append(currentLeaves,
 				hashAndPos{node.data, p.calculatePosition(node)})
 		}
@@ -954,10 +954,10 @@ func FuzzModifyProofChain(f *testing.F) {
 				t.Fatalf("FuzzModifyProof fail at block %d. Error: %v",
 					b, err)
 			}
-			if uint64(len(p.nodeMap)) != p.numLeaves-p.numDels {
+			if uint64(len(p.NodeMap)) != p.numLeaves-p.numDels {
 				err := fmt.Errorf("FuzzModifyProof fail at block %d: "+
 					"have %d leaves in map but only %d leaves in total",
-					b, len(p.nodeMap), p.numLeaves-p.numDels)
+					b, len(p.NodeMap), p.numLeaves-p.numDels)
 				t.Fatal(err)
 			}
 		}

--- a/stump_test.go
+++ b/stump_test.go
@@ -53,7 +53,7 @@ func FuzzStump(f *testing.F) {
 		p := NewAccumulator(true)
 		stump := Stump{}
 
-		leaves, delHashes, _ := getAddsAndDels(uint32(p.numLeaves), startLeaves, delCount)
+		leaves, delHashes, _ := getAddsAndDels(uint32(p.NumLeaves), startLeaves, delCount)
 		err := p.Modify(leaves, nil, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -88,7 +88,7 @@ func FuzzStump(f *testing.F) {
 			t.Fatal(err)
 		}
 
-		modifyLeaves, _, _ := getAddsAndDels(uint32(p.numLeaves), 0, 0)
+		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), 0, 0)
 		err = p.Modify(modifyLeaves, delHashes, proof.Targets)
 		if err != nil {
 			t.Fatal(err)

--- a/stump_test.go
+++ b/stump_test.go
@@ -70,16 +70,16 @@ func FuzzStump(f *testing.F) {
 		}
 
 		// Check that the roots are the same after the addition.
-		if len(p.roots) != len(stump.Roots) {
+		if len(p.Roots) != len(stump.Roots) {
 			t.Fatalf("FuzzStump fail: jHave %d roots for pollard and %d roots for stump."+
-				"\nStump:\n%s\nPollard:\n%s\n", len(p.roots), len(stump.Roots),
-				printHashes(stump.Roots), printPolNodes(p.roots))
+				"\nStump:\n%s\nPollard:\n%s\n", len(p.Roots), len(stump.Roots),
+				printHashes(stump.Roots), printPolNodes(p.Roots))
 		}
-		for i := range p.roots {
-			if p.roots[i].data != stump.Roots[i] {
+		for i := range p.Roots {
+			if p.Roots[i].data != stump.Roots[i] {
 				t.Fatalf("FuzzStump fail: Roots do not equal between pollard and stump."+
 					"\nStump:\n%s\nPollard:\n%s\n%s\n",
-					printHashes(stump.Roots), printPolNodes(p.roots), p.String())
+					printHashes(stump.Roots), printPolNodes(p.Roots), p.String())
 			}
 		}
 
@@ -105,16 +105,16 @@ func FuzzStump(f *testing.F) {
 		}
 
 		// Check that the roots are the same after addition/deletion.
-		if len(p.roots) != len(stump.Roots) {
+		if len(p.Roots) != len(stump.Roots) {
 			t.Fatalf("FuzzStump fail: jHave %d roots for pollard and %d roots for stump."+
-				"\nStump:\n%s\nPollard:\n%s\n", len(p.roots), len(stump.Roots),
-				printHashes(stump.Roots), printPolNodes(p.roots))
+				"\nStump:\n%s\nPollard:\n%s\n", len(p.Roots), len(stump.Roots),
+				printHashes(stump.Roots), printPolNodes(p.Roots))
 		}
-		for i := range p.roots {
-			if p.roots[i].data != stump.Roots[i] {
+		for i := range p.Roots {
+			if p.Roots[i].data != stump.Roots[i] {
 				t.Fatalf("FuzzStump fail: Roots do not equal between pollard and stump."+
 					"\nStump:\n%s\nPollard:\n%s\n%s\n",
-					printHashes(stump.Roots), printPolNodes(p.roots), p.String())
+					printHashes(stump.Roots), printPolNodes(p.Roots), p.String())
 			}
 		}
 	})
@@ -165,16 +165,16 @@ func FuzzStumpChain(f *testing.F) {
 			}
 
 			// Check that the roots are the same after addition/deletion.
-			if len(p.roots) != len(stump.Roots) {
+			if len(p.Roots) != len(stump.Roots) {
 				t.Fatalf("FuzzStumpChain fail at block %d: Have %d roots for pollard and %d roots for stump."+
-					"\nStump:\n%s\nPollard:\n%s\n", b, len(p.roots), len(stump.Roots),
-					printHashes(stump.Roots), printPolNodes(p.roots))
+					"\nStump:\n%s\nPollard:\n%s\n", b, len(p.Roots), len(stump.Roots),
+					printHashes(stump.Roots), printPolNodes(p.Roots))
 			}
-			for i := range p.roots {
-				if p.roots[i].data != stump.Roots[i] {
+			for i := range p.Roots {
+				if p.Roots[i].data != stump.Roots[i] {
 					t.Fatalf("FuzzStumpChain fail at block %d: Roots do not equal between pollard and stump."+
 						"\nStump:\n%s\nPollard:\n%s\n%s\n", b,
-						printHashes(stump.Roots), printPolNodes(p.roots), p.String())
+						printHashes(stump.Roots), printPolNodes(p.Roots), p.String())
 				}
 			}
 		}

--- a/utils.go
+++ b/utils.go
@@ -579,11 +579,11 @@ func proofPositions(targets []uint64, numLeaves uint64, forestRows uint8) ([]uin
 
 // String prints out the whole thing. Only viable for forest that have height of 5 and less.
 func (p *Pollard) String() string {
-	fh := treeRows(p.numLeaves)
+	fh := treeRows(p.NumLeaves)
 
 	// The accumulator should be less than 6 rows.
 	if fh > 6 {
-		s := fmt.Sprintf("Can't print %d leaves. roots:\n", p.numLeaves)
+		s := fmt.Sprintf("Can't print %d leaves. roots:\n", p.NumLeaves)
 		roots := p.GetRoots()
 		for i, r := range roots {
 			s += fmt.Sprintf("\t%d %x\n", i, r.mini())
@@ -598,7 +598,7 @@ func (p *Pollard) String() string {
 
 		for j := uint8(0); j < rowlen; j++ {
 			var valstring string
-			max, err := maxPositionAtRow(h, fh, p.numLeaves)
+			max, err := maxPositionAtRow(h, fh, p.NumLeaves)
 			ok := max >= uint64(pos)
 			if ok && err == nil {
 				val := p.getHash(uint64(pos))
@@ -675,10 +675,10 @@ func getRootPosition(position uint64, numLeaves uint64, forestRows uint8) (uint6
 // AllSubTreesToString returns a string of all the individual subtrees in the accumulator.
 func (p *Pollard) AllSubTreesToString() string {
 	str := ""
-	totalRows := treeRows(p.numLeaves)
+	totalRows := treeRows(p.NumLeaves)
 	for h := uint8(0); h < totalRows; h++ {
-		rootPos := rootPosition(p.numLeaves, h, totalRows)
-		if isRootPosition(rootPos, p.numLeaves, totalRows) {
+		rootPos := rootPosition(p.NumLeaves, h, totalRows)
+		if isRootPosition(rootPos, p.NumLeaves, totalRows) {
 			str += fmt.Sprintf(p.SubTreeToString(rootPos, false))
 			str += "\n"
 		}
@@ -689,11 +689,11 @@ func (p *Pollard) AllSubTreesToString() string {
 
 // SubTreeToString returns a string of the subtree that the position is in.
 func (p *Pollard) SubTreeToString(position uint64, inHex bool) string {
-	rootPosition, err := getRootPosition(position, p.numLeaves, treeRows(p.numLeaves))
+	rootPosition, err := getRootPosition(position, p.NumLeaves, treeRows(p.NumLeaves))
 	if err != nil {
 		return fmt.Sprintf("SubTreeToString error: %v", err.Error())
 	}
-	subTreeRow := detectRow(rootPosition, treeRows(p.numLeaves))
+	subTreeRow := detectRow(rootPosition, treeRows(p.NumLeaves))
 
 	if subTreeRow > 7 {
 		s := fmt.Sprintf("Can't print subtree with rows %d. roots:\n", subTreeRow)
@@ -748,7 +748,7 @@ func (p *Pollard) SubTreeToString(position uint64, inHex bool) string {
 				}
 			}
 
-			leftChild := leftChild(position, treeRows(p.numLeaves))
+			leftChild := leftChild(position, treeRows(p.NumLeaves))
 			rightChild := rightSib(leftChild)
 			nextPositions = append(nextPositions, leftChild)
 			nextPositions = append(nextPositions, rightChild)


### PR DESCRIPTION
Exporting pollard fields allow the caller to make functions such as serialization. This is important as it leaves the complexity/flexibility to the callers for additional functions they may need.