### PR TITLE
prove: Implement more memory efficient hashAndPos

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -879,20 +879,6 @@ func nodeMapToString(m map[miniHash]*polNode) string {
 	return str
 }
 
-// hashAndPosToString turns a slice of hash and pos into readable string.
-func hashAndPosToString(hnps []hashAndPos) string {
-	str := ""
-	for i, hnp := range hnps {
-		str += fmt.Sprintf("pos:%d, hash:%s", hnp.pos, hex.EncodeToString(hnp.hash[:]))
-
-		if i != len(hnps)-1 {
-			str += "\n"
-		}
-	}
-
-	return str
-}
-
 // polNodeAndPosToString turns a slice of polNode and pos into readable string.
 func polNodeAndPosToString(nodes []nodeAndPos) string {
 	str := ""


### PR DESCRIPTION
Previously the corresponding hash and pos would have to be combined into
a slice of hashAndPos and later split into two slices of []uint64 and
[]Hash.

The new hashAndPos is just the slice of []uint64 and []Hash
that's combined into one struct, eliminating the need to allocate new
slices.