### PR TITLE
prove: Add GetProofSubset

### DIFF
--- a/testdata/fuzz/FuzzGetProofSubset/02b9269ace179dd23ee9fb86b96ae932c446985cba5b4e39e5c51abc57b0e907
+++ b/testdata/fuzz/FuzzGetProofSubset/02b9269ace179dd23ee9fb86b96ae932c446985cba5b4e39e5c51abc57b0e907
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(271)
+uint32(27)
+int64(-31)

--- a/testdata/fuzz/FuzzGetProofSubset/18374851657a78e8a6bba9961dd17c129b3a1039797ced120960a8c0249b289a
+++ b/testdata/fuzz/FuzzGetProofSubset/18374851657a78e8a6bba9961dd17c129b3a1039797ced120960a8c0249b289a
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(4)
+uint32(2)
+int64(186)

--- a/testdata/fuzz/FuzzGetProofSubset/7f73a8fe20f50afe045589f9a035d7da53f0520e73b5778099e46d0253daa885
+++ b/testdata/fuzz/FuzzGetProofSubset/7f73a8fe20f50afe045589f9a035d7da53f0520e73b5778099e46d0253daa885
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(48)
+uint32(47)
+int64(179)


### PR DESCRIPTION
If a node has a proof for targets [0, 1, 2] but only wants to prove to
someone that [0] exists in the accumulator, GetProofSubset can be used
to create a proof that's only for that specific target.

This is useful for mempool and wallets alike.