### PR TITLE
Prove: Modify calculateRoots() to support deletions

### DIFF
--- a/stump.go
+++ b/stump.go
@@ -62,9 +62,13 @@ func (s *Stump) del(delHashes []Hash, proof Proof) error {
 		return fmt.Errorf("Stump update fail: Invalid proof. Error: %s", err)
 	}
 
-	// Then delete.
-	delHashes, afterProof := proofAfterDeletion(s.NumLeaves, proof)
-	modifiedRoots := calculateRoots(s.NumLeaves, delHashes, afterProof)
+	// Then calculate the modified roots.
+	modifiedRoots := calculateRoots(s.NumLeaves, nil, proof)
+
+	if len(modifiedRoots) != len(rootCandidates) {
+		return fmt.Errorf("Stump update fail: expected %d modified roots but got %d",
+			len(rootCandidates), len(modifiedRoots))
+	}
 
 	idx := 0
 	for i := len(s.Roots) - 1; i >= 0; i-- {


### PR DESCRIPTION
The changes made to calculateRoots() now enables support for calculating
the roots that happen after a deletion. This replaces the functionality
that proofAfterDeletion() along with the old calculateRoots() provided
for stump deletion. The deletion is now just M*log(N) where N = number of
leaves and M = number of targets.