### PR TITLE
prove: Refactor calculateRoots to calculateHashes

### DIFF
--- a/stump.go
+++ b/stump.go
@@ -33,7 +33,7 @@ func Verify(stump Stump, delHashes []Hash, proof Proof) ([]int, error) {
 			"hashes for those targets", len(proof.Targets), len(delHashes))
 	}
 
-	rootCandidates := calculateRoots(stump.NumLeaves, delHashes, proof)
+	_, rootCandidates := calculateHashes(stump.NumLeaves, delHashes, proof)
 	rootIndexes := make([]int, 0, len(rootCandidates))
 	for i := range stump.Roots {
 		if len(rootCandidates) > len(rootIndexes) &&
@@ -65,7 +65,7 @@ func (s *Stump) del(delHashes []Hash, proof Proof) error {
 	}
 
 	// Then calculate the modified roots.
-	modifiedRoots := calculateRoots(s.NumLeaves, nil, proof)
+	_, modifiedRoots := calculateHashes(s.NumLeaves, nil, proof)
 	if len(modifiedRoots) != len(rootIndexes) {
 		return fmt.Errorf("Stump update fail: expected %d modified roots but got %d",
 			len(rootIndexes), len(modifiedRoots))


### PR DESCRIPTION
calculateRoots is refactored to calculateHashes to support returning of the intermediate hashes that were calculated when hashing up to the root.

This is useful for updating cached proofs.