### PR TITLE
accumulator: Fix undo empty roots bug

### DIFF
--- a/testdata/fuzz/FuzzUndoChain/086b149d35967288d87b31db61a9f99c79c3dc72807ec2f2ea2d9376c86dcd24
+++ b/testdata/fuzz/FuzzUndoChain/086b149d35967288d87b31db61a9f99c79c3dc72807ec2f2ea2d9376c86dcd24
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(155)
+uint32(2)
+int64(-13)

--- a/testdata/fuzz/FuzzUndoChain/313ce4d7bf60758570d2c9edd0d6f3a24ad55c76396989052d232a0cbe91118b
+++ b/testdata/fuzz/FuzzUndoChain/313ce4d7bf60758570d2c9edd0d6f3a24ad55c76396989052d232a0cbe91118b
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(5)
+int64(73)

--- a/testdata/fuzz/FuzzUndoChain/a06ddeb31e4501a9152f97f96b0f36db70336d924fbf520870904e15650fc30b
+++ b/testdata/fuzz/FuzzUndoChain/a06ddeb31e4501a9152f97f96b0f36db70336d924fbf520870904e15650fc30b
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(7)
+int64(101)

--- a/testdata/fuzz/FuzzUndoChain/df15c4fff25f3d16d0f4135cc53a0be62f6b3a5db855e5d7358ef2cdc68d33fa
+++ b/testdata/fuzz/FuzzUndoChain/df15c4fff25f3d16d0f4135cc53a0be62f6b3a5db855e5d7358ef2cdc68d33fa
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(7)
+int64(47)


### PR DESCRIPTION
Undo empty roots would place the empty roots at the wrong row. The bug is addressed and the new tests are now able to detect the bug.