### PR TITLE
accumulator: partial pollard support

### DIFF
--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -569,6 +569,7 @@ func FuzzModify(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		sortedDelTargets := copySortedFunc(delTargets, uint64Less)
 		beforeStr := p.String()
 		beforeMap := nodeMapToString(p.NodeMap)
 
@@ -604,6 +605,7 @@ func FuzzModify(f *testing.F) {
 				"\nmodifyAdds:\n%s"+
 				"\nmodifyDels:\n%s"+
 				"\ndel targets:\n %v"+
+				"\ndel targets sorted:\n %v"+
 				"\nnodemap before modify:\n %s"+
 				"\nnodemap after modify:\n %s",
 				err,
@@ -614,6 +616,7 @@ func FuzzModify(f *testing.F) {
 				printHashes(modifyHashes),
 				printHashes(delHashes),
 				delTargets,
+				sortedDelTargets,
 				beforeMap,
 				afterMap)
 			t.Fatal(err)
@@ -639,7 +642,7 @@ func FuzzModifyChain(f *testing.F) {
 
 		p := NewAccumulator(true)
 		var totalAdds, totalDels int
-		for b := 0; b <= 100; b++ {
+		for b := 0; b <= 80; b++ {
 			adds, _, delHashes := sc.NextBlock(numAdds)
 			totalAdds += len(adds)
 			totalDels += len(delHashes)
@@ -669,7 +672,7 @@ func FuzzModifyChain(f *testing.F) {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v", b, err)
 			}
 
-			if b%10 == 0 {
+			if b%40 == 0 {
 				err = p.checkHashes()
 				if err != nil {
 					t.Fatal(err)

--- a/polnode.go
+++ b/polnode.go
@@ -247,12 +247,13 @@ func (n *polNode) deadEnd() bool {
 // prune forgets the nieces of the passed in nodes if they are not
 // marked to be remebered.
 func (n *polNode) prune() {
-	remember := n.lNiece.remember || n.rNiece.remember
-	if n.lNiece.deadEnd() && !remember {
+	remember := (n.lNiece != nil && n.lNiece.remember) ||
+		(n.rNiece != nil && n.rNiece.remember)
+	if n.lNiece != nil && n.lNiece.deadEnd() && !remember {
 		delNode(n.lNiece)
 		n.lNiece = nil
 	}
-	if n.rNiece.deadEnd() && !remember {
+	if n.rNiece != nil && n.rNiece.deadEnd() && !remember {
 		delNode(n.rNiece)
 		n.rNiece = nil
 	}

--- a/testdata/fuzz/FuzzModify/03a9d0284425eb0a2dcacdbf4a59f1f405263095e171d48e01eef1c13b90c2c1
+++ b/testdata/fuzz/FuzzModify/03a9d0284425eb0a2dcacdbf4a59f1f405263095e171d48e01eef1c13b90c2c1
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(248)
+uint32(102)
+uint32(239)

--- a/testdata/fuzz/FuzzModify/061fe3f1eb7d99c1136cc362bf5bcdbcb0d9c3f6331c63411c5c194c007c6260
+++ b/testdata/fuzz/FuzzModify/061fe3f1eb7d99c1136cc362bf5bcdbcb0d9c3f6331c63411c5c194c007c6260
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(190)
+uint32(44)
+uint32(187)

--- a/testdata/fuzz/FuzzModify/08e6a0d81de46f2d1592396ba43cf9aa2ebabb2e8432f2ecac42c025498f29db
+++ b/testdata/fuzz/FuzzModify/08e6a0d81de46f2d1592396ba43cf9aa2ebabb2e8432f2ecac42c025498f29db
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(18)
+uint32(2)
+uint32(16)

--- a/testdata/fuzz/FuzzModify/47d3784f669200adad98b91a1d2522217ca814363dfdb54d277e182d1ed81de8
+++ b/testdata/fuzz/FuzzModify/47d3784f669200adad98b91a1d2522217ca814363dfdb54d277e182d1ed81de8
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(9)
+uint32(1)
+uint32(5)

--- a/testdata/fuzz/FuzzModify/8e25461bd0f15d7ab8c72cea361b7c1680545dab2991660ffff9f330e2c0d3ea
+++ b/testdata/fuzz/FuzzModify/8e25461bd0f15d7ab8c72cea361b7c1680545dab2991660ffff9f330e2c0d3ea
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(6)
+uint32(27)
+uint32(3)

--- a/testdata/fuzz/FuzzModify/ee3e8580457bebe3fb97fc25395a717ce6a8b8facb73bb3f6906409fccd627f4
+++ b/testdata/fuzz/FuzzModify/ee3e8580457bebe3fb97fc25395a717ce6a8b8facb73bb3f6906409fccd627f4
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(7)
+uint32(1)
+uint32(5)

--- a/testdata/fuzz/FuzzModifyChain/1d155ab7320d35f0be416533dd7c47bddcec182d8d2c36f04aa9ddce286fcff7
+++ b/testdata/fuzz/FuzzModifyChain/1d155ab7320d35f0be416533dd7c47bddcec182d8d2c36f04aa9ddce286fcff7
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(601)
+uint32(0)
+int64(37)

--- a/testdata/fuzz/FuzzModifyChain/de8f6080a953a1fe5751f4a5f611e25b2a1c2cef0a9d7347b608ddefcd4fc516
+++ b/testdata/fuzz/FuzzModifyChain/de8f6080a953a1fe5751f4a5f611e25b2a1c2cef0a9d7347b608ddefcd4fc516
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(735)
+uint32(0)
+int64(168)


### PR DESCRIPTION
The pollard was only able to support bridge node capabilities, which
involve always caching every node.  The new deleteSingle function
doesn't assume that every node is present, allowing for deletions with a
partial pollard.