### PR TITLE
Add utreexo interface

### DIFF
--- a/accumulator_interface.go
+++ b/accumulator_interface.go
@@ -1,0 +1,37 @@
+package utreexo
+
+// Utreexo defines the interface that all consensus abiding Utreexo implementations
+// should have.
+type Utreexo interface {
+	// Modify subtracts then adds elements to the accumulator. The deletions are done in batches
+	// so if.
+	Modify(adds []Leaf, delHashes []Hash, proof Proof) error
+
+	// Prove returns a proof of the given hashes.
+	Prove(delHashes []Hash) (Proof, error)
+
+	// Verify returns an error if the given hashes and proof hash up to a different root than
+	// the one the accumulator has.  Remember flag of true will tell the accumulator to cache
+	// the proof if it is valid.
+	Verify(delHashes []Hash, proof Proof, remember bool) error
+
+	// Undo reverts a modification done by Modify.
+	Undo(numAdds uint64, proof Proof, delHashes, prevRoots []Hash) error
+
+	// GetRoots returns the current roots of the accumulator.
+	GetRoots() []Hash
+
+	// GetHash returns the hash at the given position. Returns an empty hash if the position either
+	// doesn't exist or if the position is not cached.
+	GetHash(position uint64) Hash
+
+	// GetNumLeaves returns the number of total additions the accumulator has ever had.
+	GetNumLeaves() uint64
+
+	// GetTreeRows returns the current tree rows the accumulator has allocated for.
+	GetTreeRows() uint8
+
+	// String returns a string representation of the accumulator only if the result of GetTreeRows
+	// is less than 7. Will return the hash of roots instead if the accumulator is too tall.
+	String() string
+}

--- a/accumulator_interface_test.go
+++ b/accumulator_interface_test.go
@@ -1,0 +1,18 @@
+package utreexo
+
+// UtreexoTest extends the Utreexo interface by adding on a few extra methods that are only useful
+// during testing.
+type UtreexoTest interface {
+	// Utreexo is the underlying Utreexo interface.
+	Utreexo
+
+	// sanityCheck checks for inconsistencies in the accumulator.
+	sanityCheck() error
+
+	// nodeMapToString returns the node map as a string. empty string or "n/a" if
+	// the implementation doesn't have a node map.
+	nodeMapToString() string
+
+	// rootToString returns the roots as a string.
+	rootToString() string
+}

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -139,7 +139,7 @@ func TestUndo(t *testing.T) {
 		}
 
 		// Create the initial starting off pollard.
-		err := p.Modify(adds, nil, nil)
+		err := p.Modify(adds, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,7 +147,7 @@ func TestUndo(t *testing.T) {
 		if err != nil {
 			t.Fatalf("TestUndo failed %d: error %v", i, err)
 		}
-		err = p.Modify(nil, test.startDels, proof.Targets)
+		err = p.Modify(nil, test.startDels, proof)
 		if err != nil {
 			t.Fatalf("TestUndo failed %d: error %v", i, err)
 		}
@@ -172,7 +172,7 @@ func TestUndo(t *testing.T) {
 		}
 
 		// Perform the modify to undo.
-		err = p.Modify(modifyAdds, test.modifyDels, modifyProof.Targets)
+		err = p.Modify(modifyAdds, test.modifyDels, modifyProof)
 		if err != nil {
 			t.Fatalf("TestUndo failed %d: error %v", i, err)
 		}
@@ -201,7 +201,7 @@ func TestUndo(t *testing.T) {
 		}
 
 		// Perform the undo.
-		err = p.Undo(uint64(len(test.modifyAdds)), modifyProof.Targets, test.modifyDels, beforeRoots)
+		err = p.Undo(uint64(len(test.modifyAdds)), modifyProof, test.modifyDels, beforeRoots)
 		if err != nil {
 			err := fmt.Errorf("TestUndo failed %d: error %v"+
 				"\nbefore:\n\n%s"+
@@ -566,7 +566,7 @@ func FuzzModify(f *testing.F) {
 
 		p := NewAccumulator(true)
 		leaves, delHashes, delTargets := getAddsAndDels(uint32(p.NumLeaves), startLeaves, delCount)
-		err := p.Modify(leaves, nil, nil)
+		err := p.Modify(leaves, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -574,7 +574,7 @@ func FuzzModify(f *testing.F) {
 		beforeMap := nodeMapToString(p.NodeMap)
 
 		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), modifyAdds, 0)
-		err = p.Modify(modifyLeaves, delHashes, delTargets)
+		err = p.Modify(modifyLeaves, delHashes, Proof{Targets: delTargets})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -650,7 +650,7 @@ func FuzzModifyChain(f *testing.F) {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v", b, err)
 			}
 
-			err = p.Verify(delHashes, proof)
+			err = p.Verify(delHashes, proof, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -665,7 +665,7 @@ func FuzzModifyChain(f *testing.F) {
 				}
 			}
 
-			err = p.Modify(adds, delHashes, proof.Targets)
+			err = p.Modify(adds, delHashes, proof)
 			if err != nil {
 				t.Fatalf("FuzzModifyChain fail at block %d. Error: %v", b, err)
 			}
@@ -731,7 +731,7 @@ func FuzzUndo(f *testing.F) {
 		// Create the starting off pollard.
 		p := NewAccumulator(true)
 		leaves, dels, _ := getAddsAndDels(uint32(p.NumLeaves), uint32(startLeaves), uint32(delCount))
-		err := p.Modify(leaves, nil, nil)
+		err := p.Modify(leaves, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -758,14 +758,14 @@ func FuzzUndo(f *testing.F) {
 		}
 
 		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), uint32(modifyAdds), 0)
-		err = p.Modify(modifyLeaves, dels, bp.Targets)
+		err = p.Modify(modifyLeaves, dels, bp)
 		if err != nil {
 			t.Fatal(err)
 		}
 		afterStr := p.String()
 		afterMap := nodeMapToString(p.NodeMap)
 
-		err = p.Undo(uint64(modifyAdds), bp.Targets, dels, beforeRoots)
+		err = p.Undo(uint64(modifyAdds), bp, dels, beforeRoots)
 		if err != nil {
 			startHashes := make([]Hash, len(leaves))
 			for i, leaf := range leaves {
@@ -933,7 +933,7 @@ func FuzzUndoChain(f *testing.F) {
 		p := NewAccumulator(true)
 
 		undoData := []struct {
-			targets   []uint64
+			proof     Proof
 			hashes    []Hash
 			prevRoots []Hash
 			adds      []Leaf
@@ -948,13 +948,14 @@ func FuzzUndoChain(f *testing.F) {
 			if err != nil {
 				t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 			}
-			undoTargs := make([]uint64, len(bp.Targets))
-			copy(undoTargs, bp.Targets)
+			undoProof := Proof{Targets: make([]uint64, len(bp.Targets)), Proof: make([]Hash, len(bp.Proof))}
+			copy(undoProof.Targets, bp.Targets)
+			copy(undoProof.Proof, bp.Proof)
 
 			undoDelHashes := make([]Hash, len(delHashes))
 			copy(undoDelHashes, delHashes)
 
-			err = p.Verify(delHashes, bp)
+			err = p.Verify(delHashes, bp, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -968,20 +969,20 @@ func FuzzUndoChain(f *testing.F) {
 			beforeLeaves := p.NumLeaves
 
 			undoData = append(undoData, struct {
-				targets   []uint64
+				proof     Proof
 				hashes    []Hash
 				prevRoots []Hash
 				adds      []Leaf
 				nodeMap   map[miniHash]polNode
 			}{
-				undoTargs,
+				undoProof,
 				undoDelHashes,
 				beforeRoot,
 				adds,
 				beforeMap,
 			})
 
-			err = p.Modify(adds, delHashes, bp.Targets)
+			err = p.Modify(adds, delHashes, bp)
 			if err != nil {
 				t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 			}
@@ -996,7 +997,7 @@ func FuzzUndoChain(f *testing.F) {
 			// Undo the last 10 modifies and re-do them.
 			if b%10 == 9 {
 				for i := 9; i >= 0; i-- {
-					err := p.Undo(uint64(len(undoData[i].adds)), undoData[i].targets, undoData[i].hashes, undoData[i].prevRoots)
+					err := p.Undo(uint64(len(undoData[i].adds)), undoData[i].proof, undoData[i].hashes, undoData[i].prevRoots)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1040,11 +1041,11 @@ func FuzzUndoChain(f *testing.F) {
 						t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 					}
 
-					err = p.Verify(delHashes, bp)
+					err = p.Verify(delHashes, bp, false)
 					if err != nil {
 						t.Fatal(err)
 					}
-					err = p.Modify(adds, delHashes, bp.Targets)
+					err = p.Modify(adds, delHashes, bp)
 					if err != nil {
 						t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 					}
@@ -1099,7 +1100,7 @@ func FuzzWriteAndRead(f *testing.F) {
 				t.Fatalf("FuzzWriteAndRead fail at block %d. Error: %v", b, err)
 			}
 
-			err = p.Modify(adds, delHashes, proof.Targets)
+			err = p.Modify(adds, delHashes, proof)
 			if err != nil {
 				t.Fatalf("FuzzWriteAndRead fail at block %d. Error: %v", b, err)
 			}

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -10,6 +10,36 @@ import (
 	"testing"
 )
 
+// Assert that Pollard implements the UtreexoTest interface.
+var _ UtreexoTest = (*Pollard)(nil)
+
+// nodeMapToString returns the node map as a string.
+//
+// Implements the UtreexoTest interface.
+func (p *Pollard) nodeMapToString() string {
+	return nodeMapToString(p.NodeMap)
+}
+
+// rootToString returns the roots as a string.
+//
+// Implements the UtreexoTest interface.
+func (p *Pollard) rootToString() string {
+	return printHashes(p.GetRoots())
+}
+
+// sanityCheck checks that the the node map is refering to a node that has the same position
+// and that the leaves hash up to the saved roots.
+//
+// Implements the UtreexoTest interface.
+func (p *Pollard) sanityCheck() error {
+	err := p.posMapSanity()
+	if err != nil {
+		return err
+	}
+
+	return p.checkHashes()
+}
+
 func (p *Pollard) posMapSanity() error {
 	if uint64(len(p.NodeMap)) != p.NumLeaves-p.NumDels {
 		err := fmt.Errorf("Have %d leaves in map but only %d leaves in total",

--- a/polnode_test.go
+++ b/polnode_test.go
@@ -64,12 +64,12 @@ func TestCalculatePosition(t *testing.T) {
 	for _, test := range tests {
 		p := NewAccumulator(true)
 
-		err := p.Modify(test.adds, nil, nil)
+		err := p.Modify(test.adds, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = p.Modify(nil, nil, test.dels)
+		err = p.Modify(nil, nil, Proof{Targets: test.dels})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,12 +147,12 @@ func TestReadPosition(t *testing.T) {
 	for _, test := range tests {
 		p := NewAccumulator(true)
 
-		err := p.Modify(test.adds, nil, nil)
+		err := p.Modify(test.adds, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = p.Modify(nil, nil, test.dels)
+		err = p.Modify(nil, nil, Proof{Targets: test.dels})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/prove.go
+++ b/prove.go
@@ -395,7 +395,7 @@ func deTwinHashAndPos(hnp hashAndPos, forestRows uint8) hashAndPos {
 
 // Verify calculates the root hashes from the passed in proof and delHashes and
 // compares it against the current roots in the pollard.
-func (p *Pollard) Verify(delHashes []Hash, proof Proof) error {
+func (p *Pollard) Verify(delHashes []Hash, proof Proof, remember bool) error {
 	if len(delHashes) == 0 {
 		return nil
 	}

--- a/stump_test.go
+++ b/stump_test.go
@@ -57,7 +57,7 @@ func FuzzStump(f *testing.F) {
 		stump := Stump{}
 
 		leaves, delHashes, _ := getAddsAndDels(uint32(p.NumLeaves), startLeaves, delCount)
-		err := p.Modify(leaves, nil, nil)
+		err := p.Modify(leaves, nil, Proof{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -92,7 +92,7 @@ func FuzzStump(f *testing.F) {
 		}
 
 		modifyLeaves, _, _ := getAddsAndDels(uint32(p.NumLeaves), 0, 0)
-		err = p.Modify(modifyLeaves, delHashes, proof.Targets)
+		err = p.Modify(modifyLeaves, delHashes, proof)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -175,7 +175,7 @@ func FuzzStumpChain(f *testing.F) {
 				t.Fatal(err)
 			}
 
-			err = p.Modify(adds, delHashes, proof.Targets)
+			err = p.Modify(adds, delHashes, proof)
 			if err != nil {
 				t.Fatalf("FuzzStumpChain fail at block %d. Error: %v", b, err)
 			}


### PR DESCRIPTION
The Utreexo interface defines a set of methods that all utreexo
implementations should abide by.

This allows for callers to easily switch between different Utreexo
implmentations as well as allowing for code reuse for different
tests.