### PR TITLE
utreexo: Avoid potential bug with isRootPosition

### DIFF
--- a/pollard.go
+++ b/pollard.go
@@ -184,7 +184,7 @@ func (p *Pollard) remove(dels []uint64) error {
 	for _, del := range dels {
 		// If a root is being deleted, then we mark it and all the leaves below
 		// it to be deleted.
-		if isRootPosition(del, p.NumLeaves, totalRows) {
+		if isRootPosition(del, p.NumLeaves) {
 			err := p.deleteRoot(del)
 			if err != nil {
 				return err
@@ -281,7 +281,7 @@ func (p *Pollard) deleteSingle(del uint64) error {
 	// return early.
 	totalRows := treeRows(p.NumLeaves)
 	to := parent(del, totalRows)
-	if isRootPosition(to, p.NumLeaves, totalRows) {
+	if isRootPosition(to, p.NumLeaves) {
 		toNode.aunt = nil
 		return nil
 	}
@@ -359,7 +359,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 
 	// Add in the empty roots that was removed by the deletions to the prevRoots.
 	for _, del := range dels {
-		if isRootPosition(del, p.NumLeaves, treeRows(p.NumLeaves)) {
+		if isRootPosition(del, p.NumLeaves) {
 			tree, _, _, err := detectOffset(del, p.NumLeaves)
 			if err != nil {
 				return err
@@ -431,7 +431,7 @@ func (p *Pollard) undoDels(dels []uint64, delHashes []Hash) error {
 	for i := len(pnps) - 1; i >= 0; i-- {
 		pnp := pnps[i]
 
-		if isRootPosition(pnp.pos, p.NumLeaves, treeRows(p.NumLeaves)) {
+		if isRootPosition(pnp.pos, p.NumLeaves) {
 			tree, _, _, err := detectOffset(pnp.pos, p.NumLeaves)
 			if err != nil {
 				return err

--- a/prove.go
+++ b/prove.go
@@ -579,7 +579,7 @@ func calculateHashes(numLeaves uint64, delHashes []Hash, proof Proof) (hashAndPo
 		}
 
 		// This means we hashed all the way to the top of this subtree.
-		if isRootPositionOnRow(provePos, numLeaves, row, totalRows) {
+		if isRootPositionOnRow(provePos, numLeaves, row) {
 			calculatedRootHashes = append(calculatedRootHashes, proveHash)
 			continue
 		}
@@ -847,7 +847,7 @@ func getNewPositions(blockTargets []uint64, slice hashAndPos, numLeaves uint64, 
 
 		nextPos := pos
 		for _, target := range blockTargets {
-			if isRootPositionOnRow(nextPos, numLeaves, row, totalRows) {
+			if isRootPositionOnRow(nextPos, numLeaves, row) {
 				break
 			}
 
@@ -866,7 +866,7 @@ func getNewPositions(blockTargets []uint64, slice hashAndPos, numLeaves uint64, 
 		if appendRoots {
 			newSlice.Append(nextPos, hash)
 		} else {
-			if !isRootPositionOnRow(nextPos, numLeaves, row, totalRows) {
+			if !isRootPositionOnRow(nextPos, numLeaves, row) {
 				newSlice.Append(nextPos, hash)
 			}
 		}

--- a/utils.go
+++ b/utils.go
@@ -108,16 +108,16 @@ func rootPosition(leaves uint64, h, forestRows uint8) uint64 {
 
 // isRootPosition checks if the current position is a root given the number of
 // leaves and the entire rows of the forest.
-func isRootPosition(position, numLeaves uint64, forestRows uint8) bool {
-	row := detectRow(position, forestRows)
-	return isRootPositionOnRow(position, numLeaves, row, forestRows)
+func isRootPosition(position, numLeaves uint64) bool {
+	row := detectRow(position, treeRows(numLeaves))
+	return isRootPositionOnRow(position, numLeaves, row)
 }
 
 // isRootPosition checks if the current position is a root given the number of
 // leaves, current row, and the entire rows of the forest.
-func isRootPositionOnRow(position, numLeaves uint64, row, forestRows uint8) bool {
+func isRootPositionOnRow(position, numLeaves uint64, row uint8) bool {
 	rootPresent := numLeaves&(1<<row) != 0
-	rootPos := rootPosition(numLeaves, row, forestRows)
+	rootPos := rootPosition(numLeaves, row, treeRows(numLeaves))
 
 	return rootPresent && rootPos == position
 }
@@ -503,7 +503,7 @@ func proofPositions(targets []uint64, numLeaves uint64, totalRows uint8) ([]uint
 			break
 		}
 
-		if isRootPositionOnRow(target, numLeaves, row, totalRows) {
+		if isRootPositionOnRow(target, numLeaves, row) {
 			continue
 		}
 
@@ -633,7 +633,7 @@ func AllSubTreesToString(ts ToString) string {
 	totalRows := treeRows(ts.GetNumLeaves())
 	for h := uint8(0); h < totalRows; h++ {
 		rootPos := rootPosition(ts.GetNumLeaves(), h, totalRows)
-		if isRootPosition(rootPos, ts.GetNumLeaves(), totalRows) {
+		if isRootPosition(rootPos, ts.GetNumLeaves()) {
 			str += fmt.Sprintf(SubTreeToString(ts, rootPos, false))
 			str += "\n"
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -10,6 +10,39 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+func TestIsRootPosition(t *testing.T) {
+	var tests = []struct {
+		position  uint64
+		numLeaves uint64
+		expect    bool
+	}{
+		// 02
+		// |---\
+		// 00  01
+		{position: 0, numLeaves: 2, expect: false},
+		{position: 1, numLeaves: 2, expect: false},
+		{position: 2, numLeaves: 2, expect: true},
+
+		// |-------\
+		// 04
+		// |---\   |---\
+		// 00  01  02
+		{position: 0, numLeaves: 3, expect: false},
+		{position: 1, numLeaves: 3, expect: false},
+		{position: 2, numLeaves: 3, expect: true},
+		{position: 3, numLeaves: 3, expect: false},
+		{position: 4, numLeaves: 3, expect: true},
+	}
+
+	for _, test := range tests {
+		got := isRootPosition(test.position, test.numLeaves)
+		if test.expect != got {
+			t.Fatalf("Expected %v but got %v for position:%d, numleaves:%d",
+				test.expect, got, test.position, test.numLeaves)
+		}
+	}
+}
+
 func TestTranslatePos(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The totalRows argument in isRootPosition depended on the totalRows being the minimum possible for the numleaves. For example, it's possible to have a numleaves of 1 but have a totalRows of 50.

However, for isRootPosition to work correctly, totalRows always needed to equal treeRows(numLeaves). This meant that if you gave position=0, numleaves=1, totalRows=50, isRootPosition would return false even though it should return true.

Because of this, isRootPosition and isRootPositionOnRow is changed to only take in the numleaves to avoid future bugs.