### PR TITLE
utreexo/utils: Add proofPosition

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -538,6 +538,24 @@ func inForest(pos, numLeaves uint64, forestRows uint8) bool {
 	return pos < numLeaves
 }
 
+// proofPosition is a simpler and less memory allocating version of proofPositions.
+// It only works for a singular target and returns only the positions that are needed to
+// prove the given position.
+func proofPosition(target uint64, numLeaves uint64, totalRows uint8) []uint64 {
+	proofs := make([]uint64, 0, totalRows*2)
+
+	pos := target
+	for h := detectRow(target, totalRows); h <= totalRows; h++ {
+		if isRootPositionTotalRows(pos, numLeaves, totalRows) {
+			break
+		}
+		proofs = append(proofs, sibling(pos))
+		pos = parent(pos, totalRows)
+	}
+
+	return proofs
+}
+
 // proofPositions returns all the positions that are needed to prove targets passed in.
 // NOTE: the passed in targets MUST be sorted.
 func proofPositions(targets []uint64, numLeaves uint64, totalRows uint8) ([]uint64, []uint64) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,12 +3,36 @@ package utreexo
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
 
 	"golang.org/x/exp/slices"
 )
+
+func TestProofPosition(t *testing.T) {
+	var tests = []struct {
+		position  uint64
+		numLeaves uint64
+		totalRows uint8
+	}{
+		{numLeaves: 2, totalRows: 50},
+		{numLeaves: 2, totalRows: 1},
+		{numLeaves: 15, totalRows: 50},
+		{numLeaves: 4454546, totalRows: 50},
+	}
+
+	for _, test := range tests {
+		got := proofPosition(test.position, test.numLeaves, test.totalRows)
+		expect, _ := proofPositions([]uint64{test.position}, test.numLeaves, test.totalRows)
+
+		if !reflect.DeepEqual(got, expect) {
+			t.Fatalf("expected %v, got %v for numleaves %d, totalrows %d",
+				expect, got, test.numLeaves, test.totalRows)
+		}
+	}
+}
 
 func TestInForest(t *testing.T) {
 	var tests = []struct {


### PR DESCRIPTION
proofPosition allocates less memory than proofPositions when the caller only needs the proof positions for a single position.