### PR TITLE
utreexo/pollard,utils: add totalRows arg to getLowestRoot

### DIFF
--- a/pollard.go
+++ b/pollard.go
@@ -388,7 +388,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 
 // undoSingleAdd undoes one leaf that was added to the accumulator.
 func (p *Pollard) undoSingleAdd() {
-	lowestRootRow := getLowestRoot(p.NumLeaves)
+	lowestRootRow := getLowestRoot(p.NumLeaves, treeRows(p.NumLeaves))
 	for row := int(lowestRootRow); row >= 0; row-- {
 		lowestRoot := p.Roots[len(p.Roots)-1]
 		p.Roots = p.Roots[:len(p.Roots)-1]

--- a/utils.go
+++ b/utils.go
@@ -316,12 +316,10 @@ func detectRow(position uint64, forestRows uint8) uint8 {
 }
 
 // getLowestRoot returns the row of the lowest root given the number of leaves
-// and the forestRows.
-func getLowestRoot(numLeaves uint64) uint8 {
-	forestRows := treeRows(numLeaves)
-
+// and the total rows.
+func getLowestRoot(numLeaves uint64, totalRows uint8) uint8 {
 	row := uint8(0)
-	for ; row <= forestRows; row++ {
+	for ; row <= totalRows; row++ {
 		rootPresent := numLeaves&(1<<row) != 0
 		if rootPresent {
 			break


### PR DESCRIPTION
Refactoring getLowestRoot to take in totalRows allows for callers to get the lowest root of any arbitrary totalRows instead of the one that's calculated by treeRows.