### PR TITLE
utreexo/utils: Fetch total rows instead of calling treeRows

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -608,12 +608,13 @@ func proofPositions(targets []uint64, numLeaves uint64, totalRows uint8) ([]uint
 type ToString interface {
 	GetRoots() []Hash
 	GetNumLeaves() uint64
+	GetTreeRows() uint8
 	GetHash(uint64) Hash
 }
 
 // String prints out the whole thing. Only viable for forest that have height of 5 and less.
 func String(ts ToString) string {
-	fh := treeRows(ts.GetNumLeaves())
+	fh := ts.GetTreeRows()
 
 	// The accumulator should be less than 6 rows.
 	if fh > 6 {


### PR DESCRIPTION
Some Utreexo implementations may have allocated more rows than the one treeRows returns and therefore some positions may be missing when printed as the positions calculated may be incorrect. Fetching for total rows solves this problem.