### PR TITLE
utreexo: add mappollard

### DIFF
--- a/accumulator_interface_test.go
+++ b/accumulator_interface_test.go
@@ -13,6 +13,10 @@ type UtreexoTest interface {
 	// the implementation doesn't have a node map.
 	nodeMapToString() string
 
+	// cachedMapToString returns the node map as a string. empty string or "n/a" if
+	// the implementation doesn't have a cached map.
+	cachedMapToString() string
+
 	// rootToString returns the roots as a string.
 	rootToString() string
 }

--- a/mappollard.go
+++ b/mappollard.go
@@ -1,0 +1,1103 @@
+package utreexo
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sort"
+
+	"golang.org/x/exp/slices"
+)
+
+// Assert that MapPollard implements the Utreexo interface.
+var _ Utreexo = (*MapPollard)(nil)
+
+// MapPollard is an implementation of the utreexo accumulators that supports pollard
+// functionality.
+type MapPollard struct {
+	// CachedLeaves are the positions of the leaves that we always have cached.
+	CachedLeaves map[Hash]uint64
+
+	// Nodes are the leaves in the accumulator. The hashes are mapped to their
+	// position in the accumulator.
+	Nodes map[uint64]Leaf
+
+	// NumLeaves are the number of total additions that have happened in the
+	// accumulator.
+	NumLeaves uint64
+
+	// TotalRows is the number of rows the accumulator has allocated for.
+	TotalRows uint8
+}
+
+// NewMapPollard returns a MapPollard with the nodes map initialized.
+// NOTE: The default total rows is set to 50. This avoids costly remapping.
+// For printing out the pollard for debugging purposes, set TotalRows 0 for
+// pretty printing.
+func NewMapPollard() MapPollard {
+	return MapPollard{
+		CachedLeaves: make(map[Hash]uint64),
+		Nodes:        make(map[uint64]Leaf),
+		TotalRows:    50,
+	}
+}
+
+// Modify takes in the additions and deletions and updates the accumulator accordingly.
+func (m *MapPollard) Modify(adds []Leaf, delHashes []Hash, proof Proof) error {
+	err := m.remove(proof, delHashes)
+	if err != nil {
+		return err
+	}
+
+	err = m.add(adds)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// String prints out the whole thing. Only viable for forest that have height of 5 and less.
+func (m *MapPollard) String() string {
+	return String(m)
+}
+
+// AllSubTreesToString returns a string of all the individual subtrees in the accumulator.
+func (m *MapPollard) AllSubTreesToString() string {
+	return AllSubTreesToString(m)
+}
+
+// add adds the slice of leaves to the accumulator.  It caches the leaves that have the
+// remember field set to true.
+func (m *MapPollard) add(adds []Leaf) error {
+	for _, add := range adds {
+		// Add to the accumulator.
+		err := m.addSingle(add)
+		if err != nil {
+			return err
+		}
+
+		m.NumLeaves++
+	}
+
+	return nil
+}
+
+// niecesPresent returns if either of the nieces exist for the given position.
+func (m *MapPollard) niecesPresent(pos uint64) bool {
+	if detectRow(pos, m.TotalRows) == 0 {
+		return false
+	}
+
+	lNiecePos := leftChild(sibling(pos), m.TotalRows)
+	rNiecePos := rightChild(sibling(pos), m.TotalRows)
+	_, lNieceFound := m.Nodes[lNiecePos]
+	_, rNieceFound := m.Nodes[rNiecePos]
+
+	return lNieceFound || rNieceFound
+}
+
+// prunePosition prunes the node and its sibling at the given position if:
+// 1: it and its sibling aren't marked as remembered.
+// 2: it or the sibling has no nieces present.
+func (m *MapPollard) prunePosition(pos uint64) {
+	node := m.Nodes[pos]
+	sibNode := m.Nodes[sibling(pos)]
+
+	// Remove the node if:
+	// 1: if either of the nodes aren't marked to be remembered.
+	// 2: if either of the nieces for the given node aren't present.
+	if !node.Remember && !sibNode.Remember {
+		if !m.niecesPresent(sibling(pos)) {
+			delete(m.Nodes, sibling(pos))
+		}
+
+		if !m.niecesPresent(pos) {
+			delete(m.Nodes, pos)
+		}
+	}
+}
+
+// pruneNieces prunes the nieces of the given position if they are not needed.
+func (m *MapPollard) pruneNieces(pos uint64) {
+	if detectRow(pos, m.TotalRows) == 0 {
+		return
+	}
+	lChild := leftChild(pos, m.TotalRows)
+
+	m.prunePosition(lChild)
+}
+
+// forgetUnneededDel prunes the unneeded positions after the deletion of the passed in position.
+func (m *MapPollard) forgetUnneededDel(del uint64) error {
+	// We never need to forget the root. Can break early here.
+	if isRootPositionTotalRows(del, m.NumLeaves, m.TotalRows) {
+		return nil
+	}
+
+	parentPos := del
+
+	// On each row, we determine if myself or my sibling still needs to be remembered.
+	//
+	// The cases in which myself needs to be remembered are:
+	// 1: My sibling is to be remembered.
+	// 2: I have nieces.
+	//
+	// The cases in which my sibling needs to be remembered are:
+	// 1: Myself needs to be remembered.
+	// 2: My sibling as nieces.
+	for row := detectRow(del, m.TotalRows); row <= m.TotalRows; row++ {
+		parentPos = parent(parentPos, m.TotalRows)
+
+		// Break if we're on a root.
+		if isRootPositionTotalRows(parentPos, m.NumLeaves, m.TotalRows) {
+			break
+		}
+
+		// Prune the parentPos and its sibling.
+		m.prunePosition(parentPos)
+	}
+
+	return nil
+}
+
+// addSingle adds one leaf to the accumulator.  If the remember field is set to true, the leaf
+// will be cached.
+func (m *MapPollard) addSingle(add Leaf) error {
+	totalRows, err := m.remap()
+	if err != nil {
+		return err
+	}
+
+	position := m.NumLeaves
+	pNode := add
+
+	m.Nodes[position] = Leaf{Hash: add.Hash, Remember: add.Remember}
+	if add.Remember {
+		m.CachedLeaves[add.Hash] = position
+	}
+
+	for h := uint8(0); (m.NumLeaves>>h)&1 == 1; h++ {
+		rootPos := rootPosition(m.NumLeaves, h, totalRows)
+		node, ok := m.Nodes[rootPos]
+		if !ok {
+			return fmt.Errorf("Add fail. Didn't find root at %d. NumLeaves %d",
+				rootPos, m.NumLeaves)
+		}
+
+		// If the root is empty, then we move up the current node and all its children.
+		if node.Hash == empty {
+			// Move up the current node.
+			delete(m.Nodes, position)
+			if add.Remember && pNode.Hash == add.Hash {
+				_, exists := m.CachedLeaves[add.Hash]
+				if exists {
+					m.CachedLeaves[add.Hash] = parent(position, totalRows)
+				}
+			}
+
+			// Move up the children. Have to give it +1 with the numleaves as we need
+			// them to move up to the positions after the add.
+			err = m.moveUpDescendants(position, rootPos, m.NumLeaves+1)
+			if err != nil {
+				return err
+			}
+		} else {
+			pNode = Leaf{Hash: parentHash(node.Hash, pNode.Hash)}
+		}
+
+		position = parent(position, totalRows)
+		m.Nodes[position] = pNode
+		m.pruneNieces(position)
+	}
+
+	return nil
+}
+
+// moveUpDescendants calculates the new positions for the children of the given position
+// and re-inserts them into the map of nodes with their new positions. The function
+// recursively moves up children this until the bottom-most row.
+func (m *MapPollard) moveUpDescendants(position, delPos, numLeaves uint64) error {
+	row := int(detectRow(position, m.TotalRows))
+	if row == 0 {
+		return nil
+	}
+
+	toMoveUp := []uint64{position, sibling(position)}
+	slices.Sort(toMoveUp)
+
+	next := make([]uint64, 0, len(toMoveUp)*2)
+	for h := row; h >= 0; h-- {
+		for i := range toMoveUp {
+			nextChildren, err := m.moveUpNieces(toMoveUp[i], delPos, numLeaves)
+			if err != nil {
+				return err
+			}
+
+			next = mergeSortedSlicesFunc(next, nextChildren, uint64Cmp)
+		}
+
+		toMoveUp = next
+		next = next[:0]
+	}
+
+	return nil
+}
+
+// moveUpNieces moves up the nieces of the given position.
+func (m *MapPollard) moveUpNieces(position, delPos, numLeaves uint64) ([]uint64, error) {
+	row := detectRow(position, m.TotalRows)
+	if row == 0 {
+		return nil, nil
+	}
+
+	l, err := m.moveUpChild(sibling(position), delPos, numLeaves, leftChild)
+	if err != nil {
+		return nil, err
+	}
+	r, err := m.moveUpChild(sibling(position), delPos, numLeaves, rightChild)
+	if err != nil {
+		return nil, err
+	}
+
+	l = append(l, r...)
+	return l, nil
+}
+
+// moveUpChild moves up the children of the given position to what their next position would
+// be after delPos has been deleted.
+func (m *MapPollard) moveUpChild(position, delPos, numLeaves uint64,
+	child func(uint64, uint8) uint64) ([]uint64, error) {
+
+	c := child(sibling(position), m.TotalRows)
+	nextPos, err := calcNextPosition(c, delPos, m.TotalRows)
+	if err != nil {
+		return nil, err
+	}
+
+	lVal, found := m.Nodes[c]
+	if found {
+		delete(m.Nodes, c)
+		m.Nodes[nextPos] = lVal
+
+		_, exists := m.CachedLeaves[lVal.Hash]
+		if exists {
+			m.CachedLeaves[lVal.Hash] = nextPos
+		}
+
+		return []uint64{c}, nil
+	}
+
+	return []uint64{c}, nil
+}
+
+// remap moves up the positions of nodes that aren't at row 0 whenever the accumulator grows.
+// Returns the total number of rows needed to house numleaves+1 amount of leaves.
+func (m *MapPollard) remap() (uint8, error) {
+	nextRows := treeRows(m.NumLeaves + 1)
+	if nextRows <= m.TotalRows {
+		return m.TotalRows, nil
+	}
+
+	// Go through all the possible positions from rows 1 to total rows and
+	// move them up.
+	//
+	// We do this as it's not possible to iter and modify a map when we're
+	// modifying the keys.
+	for h := uint8(1); h <= m.TotalRows; h++ {
+		startPos := startPositionAtRow(h, m.TotalRows)
+		maxPos, err := maxPositionAtRow(h, m.TotalRows, m.NumLeaves)
+		if err != nil {
+			return 0, err
+		}
+
+		j := startPositionAtRow(h, nextRows)
+		for i := startPos; i <= maxPos; i++ {
+			hash, found := m.Nodes[i]
+			if found {
+				delete(m.Nodes, i)
+				m.Nodes[j] = hash
+			}
+
+			j++
+		}
+	}
+
+	// Go through the entire cached leaves and recalculate the proof positions.
+	// For cached leaves, looping through the map and modifying it is ok since
+	// only the values are modified.
+	for k, v := range m.CachedLeaves {
+		newPos := translatePos(v, m.TotalRows, nextRows)
+		m.CachedLeaves[k] = newPos
+	}
+
+	m.TotalRows = nextRows
+	return nextRows, nil
+}
+
+// uncacheLeaves uncaches the dels from the slice of cache leaves. It does not modify
+// the map of nodes.
+func (m *MapPollard) uncacheLeaves(dels []Hash) {
+	for _, del := range dels {
+		delete(m.CachedLeaves, del)
+	}
+}
+
+// cached checks if the given hashes are cached.
+func (m *MapPollard) cached(hashes []Hash) bool {
+	for _, hash := range hashes {
+		_, found := m.CachedLeaves[hash]
+		if !found {
+			return found
+		}
+	}
+
+	return true
+}
+
+// forgetBelow removes all the positions that are descendants of the given position.
+func (m *MapPollard) forgetBelow(position uint64) {
+	row := detectRow(position, m.TotalRows)
+	if row == 0 {
+		return
+	}
+
+	l := leftChild(position, m.TotalRows)
+	r := sibling(l)
+
+	delete(m.Nodes, l)
+	delete(m.Nodes, r)
+
+	m.forgetBelow(l)
+	m.forgetBelow(r)
+}
+
+// updateHashes updates the hashes of the upper nodes of the given position.
+func (m *MapPollard) updateHashes(position uint64, hash Hash) {
+	node := Leaf{Hash: hash}
+
+	pos := parent(position, m.TotalRows)
+	for row := detectRow(pos, m.TotalRows); row <= m.TotalRows; row++ {
+		sibPos := sibling(pos)
+		sibNode := m.Nodes[sibPos]
+
+		if isLeftNiece(pos) {
+			node.Hash = parentHash(node.Hash, sibNode.Hash)
+		} else {
+			node.Hash = parentHash(sibNode.Hash, node.Hash)
+		}
+
+		pos = parent(pos, m.TotalRows)
+
+		// Update the parent hash if we have it cached.
+		_, found := m.Nodes[pos]
+		if found {
+			m.Nodes[pos] = node
+		}
+
+		if isRootPositionTotalRows(pos, m.NumLeaves, m.TotalRows) {
+			break
+		}
+	}
+}
+
+// removeSingle removes the given position and updates relevant hashes all the way
+// up to the root.
+func (m *MapPollard) removeSingle(del uint64) error {
+	// Forget my children and my children's children.
+	m.forgetBelow(del)
+
+	// If it's a root, then mark it as empty and skip other operations.
+	if isRootPositionTotalRows(del, m.NumLeaves, m.TotalRows) {
+		m.Nodes[del] = Leaf{Hash: empty}
+		return nil
+	}
+
+	// Delete myself.
+	delete(m.Nodes, del)
+
+	// Move up my sibling.
+	node, found := m.Nodes[sibling(del)]
+	if found {
+		delete(m.Nodes, sibling(del))
+		m.Nodes[parent(del, m.TotalRows)] = node
+
+		// Update the cache position if it exists in there.
+		_, cacheFound := m.CachedLeaves[node.Hash]
+		if cacheFound {
+			newPos, err := calcNextPosition(sibling(del), del, m.TotalRows)
+			if err != nil {
+				return err
+			}
+			m.CachedLeaves[node.Hash] = newPos
+			node.Remember = true
+		}
+
+		// Move up all descendants of my sibling.
+		err := m.moveUpDescendants(sibling(del), del, m.NumLeaves)
+		if err != nil {
+			return err
+		}
+	}
+
+	m.updateHashes(del, node.Hash)
+
+	m.forgetUnneededDel(del)
+
+	return nil
+}
+
+// remove removes the targets and the delHashes from the accumulator. The del targets
+// and hashes do not have to be in the same order.
+//
+// NOTE: dels MUST be sorted.
+func (m *MapPollard) remove(proof Proof, delHashes []Hash) error {
+	// Check first that we have all the necessary nodes for deletion.
+	if !m.cached(delHashes) {
+		return fmt.Errorf("Cannot delete:\n%s\nas not all of them are cached",
+			printHashes(delHashes))
+	}
+
+	// Remove dels from the cached leaves.
+	m.uncacheLeaves(delHashes)
+
+	detwinedDels := copySortedFunc(proof.Targets, uint64Less)
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		detwinedDels = translatePositions(detwinedDels, treeRows(m.NumLeaves), m.TotalRows)
+	}
+
+	detwinedDels = deTwin(detwinedDels, m.TotalRows)
+	for _, del := range detwinedDels {
+		m.removeSingle(del)
+	}
+	return nil
+}
+
+// undoSingleAdd undo-s the last single addition and will put back empty roots that were
+// written over.
+func (m *MapPollard) undoSingleAdd(emptyRootPositions []uint64) ([]uint64, error) {
+	row := getLowestRoot(m.NumLeaves, m.TotalRows)
+	pos := rootPosition(m.NumLeaves-1, row, m.TotalRows)
+	lChild := leftChild(pos, m.TotalRows)
+
+	for h := int(row); h >= 0; h-- {
+		leaf, found := m.Nodes[pos]
+		if found {
+			delete(m.Nodes, pos)
+			delete(m.CachedLeaves, leaf.Hash)
+		}
+
+		if h != 0 {
+			if len(emptyRootPositions) > 0 &&
+				emptyRootPositions[0] == lChild {
+
+				err := m.placeEmptyRoot(lChild)
+				if err != nil {
+					return emptyRootPositions, err
+				}
+				emptyRootPositions = emptyRootPositions[1:]
+
+				m.Nodes[lChild] = Leaf{Hash: empty, Remember: true}
+			}
+		}
+
+		pos = rightChild(pos, m.TotalRows)
+		lChild = leftChild(pos, m.TotalRows)
+	}
+
+	m.NumLeaves--
+
+	return emptyRootPositions, nil
+}
+
+// placeEmptyRoot will put back the empty root at the given previous root position and
+// move down the nodes that are at the current empty root position.
+func (m *MapPollard) placeEmptyRoot(prevRootPos uint64) error {
+	sib := sibling(prevRootPos)
+	row := detectRow(sib, m.TotalRows)
+
+	for h := int(row); h > 0; h-- {
+		child, err := childMany(sib, uint8(h), m.TotalRows)
+		if err != nil {
+			return err
+		}
+
+		for i := 0; i < 1<<h; i++ {
+			pos := uint64(i) + child
+
+			curPos, err := calcNextPosition(pos, prevRootPos, m.TotalRows)
+			if err != nil {
+				return err
+			}
+
+			v, found := m.Nodes[curPos]
+			if found && v.Hash != empty {
+				delete(m.Nodes, curPos)
+
+				_, cached := m.CachedLeaves[v.Hash]
+				if cached {
+					v.Remember = true
+					m.CachedLeaves[v.Hash] = pos
+				}
+				m.Nodes[pos] = v
+			}
+		}
+	}
+
+	return nil
+}
+
+// undoDeletion undo-es all the deletions that are passed in. The deletions that happened
+// should be done in a single modify.
+func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
+	// Sort and translate the positions if needed.
+	hnp := toHashAndPos(proof.Targets, hashes)
+	if treeRows(m.NumLeaves) != m.TotalRows {
+		hnp.positions = translatePositions(hnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+		sort.Sort(hnp)
+	}
+
+	// Make separate detwined targets.
+	deTwinedTargets := make([]uint64, len(hnp.positions))
+	copy(deTwinedTargets, hnp.positions)
+	deTwinedTargets = deTwin(deTwinedTargets, m.TotalRows)
+
+	// Go through the detwined targets in descending order and move down the nodes
+	// that have moved up from the deletion.
+	for i := len(deTwinedTargets) - 1; i >= 0; i-- {
+		// If the sibling of the target exists in the accumulator, move it down by
+		// placing an empty position at the given target.
+		if inForest(sibling(deTwinedTargets[i]), m.NumLeaves, m.TotalRows) {
+			err := m.placeEmptyRoot(deTwinedTargets[i])
+			if err != nil {
+				return err
+			}
+		}
+
+		// Grab the former sibling in the parent position and move it down to its
+		// previous position.
+		sib := parent(deTwinedTargets[i], m.TotalRows)
+		prevPos := calcPrevPosition(sib, deTwinedTargets[i], m.TotalRows)
+		v, found := m.Nodes[sib]
+		if found {
+			_, cached := m.CachedLeaves[v.Hash]
+			if cached {
+				m.CachedLeaves[v.Hash] = prevPos
+				v.Remember = true
+			}
+
+			delete(m.Nodes, sib)
+			m.Nodes[prevPos] = v
+		}
+	}
+
+	// Calculate the positions of the proofs and translate them if needed and
+	// then place in the proof hashes into the calculated positions.
+	sortedTargets := copySortedFunc(proof.Targets, uint64Less)
+	proofPos, _ := proofPositions(sortedTargets, m.NumLeaves, treeRows(m.NumLeaves))
+	if treeRows(m.NumLeaves) != m.TotalRows {
+		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
+		proofPos = translatePositions(proofPos, treeRows(m.NumLeaves), m.TotalRows)
+	}
+	for i := range proofPos {
+		pos := proofPos[i]
+		_, found := m.Nodes[pos]
+		if !found {
+			m.Nodes[pos] = Leaf{Hash: proof.Proof[i]}
+		}
+	}
+
+	// Calculate the previous hashes and their positions and translate them if needed.
+	newhnp, _ := calculateHashes(m.NumLeaves, hashes, proof)
+	if treeRows(m.NumLeaves) != m.TotalRows {
+		newhnp.positions = translatePositions(newhnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+		sort.Sort(newhnp)
+	}
+
+	// Go through all the calculated positions and place them int the accumulator.
+	for i, pos := range newhnp.positions {
+		// If the position is a target, then set the remember to true.
+		remember := false
+		for _, target := range proof.Targets {
+			if treeRows(m.NumLeaves) != m.TotalRows {
+				translated := translatePos(target, treeRows(m.NumLeaves), m.TotalRows)
+				if pos == translated {
+					remember = true
+				}
+			} else {
+				if pos == target {
+					remember = true
+				}
+			}
+		}
+		m.Nodes[pos] = Leaf{Hash: newhnp.hashes[i], Remember: remember}
+
+		// Only add it to the cached leaves if remember is true.
+		if remember {
+			m.CachedLeaves[newhnp.hashes[i]] = pos
+		}
+	}
+
+	return nil
+}
+
+// getRootsAfterDel will place empty roots if the last deletion had deleted roots. It will not update
+// the hashes themselves.
+func (m *MapPollard) getRootsAfterDel(numAdds uint64, targets, prevRootPos []uint64, origPrevRoots []Hash) []Hash {
+	prevRoots := make([]Hash, len(origPrevRoots))
+	copy(prevRoots, origPrevRoots)
+
+	detwined := deTwin(translatePositions(copySortedFunc(targets, uint64Less),
+		treeRows(m.NumLeaves-numAdds), m.TotalRows), m.TotalRows)
+
+	for i := range detwined {
+		for j := range prevRootPos {
+			if detwined[i] == prevRootPos[j] {
+				prevRoots[j] = empty
+			}
+		}
+	}
+
+	return prevRoots
+}
+
+// getWrittenOverEmptyRoots returns the positions of the empty roots that have been written
+// over after the addition to the accumulator.
+func (m *MapPollard) getWrittenOverEmptyRoots(numAdds uint64, origTargets []uint64, origPrevRoots []Hash) ([]uint64, error) {
+	prevRootPos := rootPositions(m.NumLeaves-numAdds, m.TotalRows)
+
+	// Get the roots after the deletion has happened.
+	prevRoots := m.getRootsAfterDel(numAdds, origTargets, prevRootPos, origPrevRoots)
+
+	// Get the positions of empty roots that are written over after the add.
+	destroyedPositions := rootsToDestory(numAdds, m.NumLeaves-numAdds, prevRoots)
+
+	// Translate the positions if needed.
+	if treeRows(m.NumLeaves) != m.TotalRows {
+		destroyedPositions = translatePositions(destroyedPositions, treeRows(m.NumLeaves), m.TotalRows)
+	}
+
+	// Loop through all the previous roots and only add their position to the previous
+	// empty root positions if it's been destroyed on the add.
+	prevEmptyRootPos := make([]uint64, 0, len(prevRootPos))
+	for i, root := range prevRoots {
+		// Look for empty roots.
+		if root == empty {
+			// Only append the empty roots if they've been written over.
+			for _, destroyed := range destroyedPositions {
+				if destroyed == prevRootPos[i] {
+					prevEmptyRootPos = append(prevEmptyRootPos, prevRootPos[i])
+				}
+			}
+		}
+	}
+
+	return prevEmptyRootPos, nil
+}
+
+// undoAdd will remove the additions that had happened and will place empty roots back to where they were.
+func (m *MapPollard) undoAdd(numAdds uint64, origTargets []uint64, origPrevRoots []Hash) error {
+	// Get the previously empty roots positions that have been written over by the add.
+	// These empty roots will be placed back into the accumulator.
+	prevEmptyRootPos, err := m.getWrittenOverEmptyRoots(numAdds, origTargets, origPrevRoots)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < int(numAdds); i++ {
+		prevEmptyRootPos, err = m.undoSingleAdd(prevEmptyRootPos)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+// Undo will undo the last modify. The numAdds, proof, hashes, MUST be the data from the previous modify.
+// The origPrevRoots MUST be the roots that this Undo will go back to.
+func (m *MapPollard) Undo(numAdds uint64, proof Proof, hashes, origPrevRoots []Hash) error {
+	err := m.undoAdd(numAdds, proof.Targets, origPrevRoots)
+	if err != nil {
+		return err
+	}
+
+	err = m.undoDeletion(proof, hashes)
+	if err != nil {
+		return err
+	}
+
+	_, rootPos := m.getRoots()
+	for i := range rootPos {
+		var remember bool
+		_, found := m.CachedLeaves[origPrevRoots[i]]
+		if found {
+			remember = true
+		}
+		m.Nodes[rootPos[i]] = Leaf{Hash: origPrevRoots[i], Remember: remember}
+	}
+
+	return nil
+}
+
+// Prove returns a proof of all the targets that are passed in.
+// TODO: right now it refuses to prove anything but the explicitly cached leaves.
+// There may be some leaves that it could prove that's not cached due to the proofs
+// overlapping.
+func (m *MapPollard) Prove(proveHashes []Hash) (Proof, error) {
+	// Check that the targets are proveable.
+	if !m.cached(proveHashes) {
+		return Proof{}, fmt.Errorf("Cannot prove:\n%s\nas not all of them are cached",
+			printHashes(proveHashes))
+	}
+
+	origTargets := make([]uint64, len(proveHashes))
+	for i := range origTargets {
+		origTargets[i] = m.CachedLeaves[proveHashes[i]]
+	}
+
+	// Sort targets first. Copy to avoid mutating the original.
+	targets := copySortedFunc(origTargets, uint64Less)
+
+	// The positions of the hashes we need to prove the passed in targets.
+	proofPos, _ := proofPositions(targets, m.NumLeaves, m.TotalRows)
+
+	// Go through all the needed positions and grab the hashes for them.
+	// If the node doesn't exist, check that it's calculateable. If it is,
+	// calculate it. If it isn't, return an error.
+	hashes := make([]Hash, 0, len(proofPos))
+	for i := range proofPos {
+		pos := proofPos[i]
+		node, ok := m.Nodes[pos]
+		if !ok {
+			// Should never happen. This means that there's something wrong with the
+			// implementation since we've already checked that the proof for the leaf
+			// exists.
+			return Proof{}, fmt.Errorf("Proof position %v not cached for the requested "+
+				"target slice of: %v\nproveHashes:\n%s\nneededPositions:%v\n",
+				pos, origTargets, printHashes(proveHashes), proofPos)
+		}
+
+		hashes = append(hashes, node.Hash)
+	}
+
+	// If the map pollard is set with higher rows than what's actually needed,
+	// translate the positions.
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		for i := range origTargets {
+			origTargets[i] = translatePos(origTargets[i], m.TotalRows, treeRows(m.NumLeaves))
+		}
+	}
+
+	return Proof{Targets: origTargets, Proof: hashes}, nil
+}
+
+// Verify returns an error if the given proof and the delHashes do not hash up to the stored roots.
+// Passing the remember flag as true will cause the proof to be cached.
+func (m *MapPollard) Verify(delHashes []Hash, proof Proof, remember bool) error {
+	if treeRows(m.NumLeaves) != m.TotalRows {
+		proof.Targets = translatePositions(proof.Targets, m.TotalRows, treeRows(m.NumLeaves))
+	}
+
+	s := m.GetStump()
+	_, err := Verify(s, delHashes, proof)
+	if err != nil {
+		return err
+	}
+
+	if remember {
+		m.Ingest(delHashes, proof)
+	}
+
+	return nil
+}
+
+// trimProofPos returns a slice of proof positions with the proof positions that
+// aren't needed trimmed out.
+//
+// The given proof positions must be sorted.
+func (m *MapPollard) trimProofPos(proofPos []uint64, numLeaves uint64) []uint64 {
+	rows := treeRows(numLeaves)
+
+	i := 0
+	for ; i < len(proofPos); i++ {
+		if !inForest(proofPos[i], numLeaves, rows) {
+			break
+		}
+	}
+
+	return proofPos[:i]
+}
+
+// Ingest places the proof in the tree and remembers them.
+//
+// NOTE: there's no verification done that the passed in proof is valid. It's the
+// caller's responsibility to verify that the given proof is valid.
+func (m *MapPollard) Ingest(delHashes []Hash, proof Proof) {
+	hnp := toHashAndPos(proof.Targets, delHashes)
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		hnp.positions = translatePositions(hnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+		sort.Sort(hnp)
+	}
+
+	// Calculate and ingest the proof.
+	proofPos, _ := proofPositions(hnp.positions, m.NumLeaves, m.TotalRows)
+	if treeRows(m.NumLeaves) > m.TotalRows {
+		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
+	}
+	for i, pos := range proofPos {
+		_, found := m.Nodes[pos]
+		if !found {
+			m.Nodes[pos] = Leaf{Hash: proof.Proof[i]}
+		}
+	}
+
+	// Calculate the intermediate positions and their hashes.
+	intermediate, _ := calculateHashes(m.NumLeaves, delHashes, proof)
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		intermediate.positions = translatePositions(intermediate.positions, treeRows(m.NumLeaves), m.TotalRows)
+		sort.Sort(intermediate)
+	}
+
+	// Ingest the targets and the intermediate positions and their hashes.
+	for i, pos := range intermediate.positions {
+		remember := false
+		for i := range hnp.positions {
+			if hnp.positions[i] == pos {
+				remember = true
+				break
+			}
+		}
+		m.Nodes[pos] = Leaf{Hash: intermediate.hashes[i], Remember: remember}
+		if remember {
+			m.CachedLeaves[intermediate.hashes[i]] = pos
+		}
+	}
+}
+
+// getRoots returns the hashes of the roots.
+func (m *MapPollard) GetRoots() []Hash {
+	roots, _ := m.getRoots()
+	return roots
+}
+
+// getRoots returns the root hashes and their positions.
+func (m *MapPollard) getRoots() ([]Hash, []uint64) {
+	nRoots := numRoots(m.NumLeaves)
+
+	roots := make([]Hash, 0, nRoots)
+	rootPositions := rootPositions(m.NumLeaves, m.TotalRows)
+	for _, rootPosition := range rootPositions {
+		node := m.Nodes[rootPosition]
+		roots = append(roots, node.Hash)
+	}
+
+	return roots, rootPositions
+}
+
+// GetHash returns the hash for the given position. Empty hash (all values are 0) is returned
+// if the given position is not cached.
+func (m *MapPollard) GetHash(pos uint64) Hash {
+	return m.Nodes[pos].Hash
+}
+
+func (m *MapPollard) highestPos() uint64 {
+	totalRows := treeRows(m.NumLeaves)
+	pos := rootPosition(m.NumLeaves, totalRows, totalRows)
+	return translatePos(pos, totalRows, m.TotalRows)
+}
+
+// GetNumLeaves returns the number of leaves that were ever added to the accumulator.
+func (m *MapPollard) GetNumLeaves() uint64 {
+	return m.NumLeaves
+}
+
+// GetTreeRows returns the tree rows that are allocated for this accumulator.
+func (m *MapPollard) GetTreeRows() uint8 {
+	return m.TotalRows
+}
+
+// GetStump returns a stump with the values fetched from the pollard.
+func (m *MapPollard) GetStump() Stump {
+	return Stump{Roots: m.GetRoots(), NumLeaves: m.NumLeaves}
+}
+
+// Write writes the entire pollard to the writer.
+func (m *MapPollard) Write(w io.Writer) (int, error) {
+	totalBytes := 0
+
+	var buf [8]byte
+
+	// Write the total rows.
+	buf[0] = m.TotalRows
+	bytes, err := w.Write(buf[:1])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+
+	// Write the number of leaves.
+	binary.LittleEndian.PutUint64(buf[:], m.NumLeaves)
+	bytes, err = w.Write(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+
+	// Write the count for the cache leaf elements in the map.
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(m.CachedLeaves)))
+	bytes, err = w.Write(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+
+	// Write the map elements.
+	for k, v := range m.CachedLeaves {
+		written, err := w.Write(k[:])
+		if err != nil {
+			return totalBytes, err
+		}
+		totalBytes += written
+
+		binary.LittleEndian.PutUint64(buf[:], v)
+		bytes, err = w.Write(buf[:])
+		if err != nil {
+			return totalBytes, err
+		}
+		totalBytes += bytes
+	}
+
+	// Write the count for the node elements in the map.
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(m.Nodes)))
+	bytes, err = w.Write(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+
+	// Write the node elements.
+	var leafBuf [33]byte
+	for k, v := range m.Nodes {
+		binary.LittleEndian.PutUint64(buf[:], k)
+		bytes, err := w.Write(buf[:])
+		if err != nil {
+			return bytes, err
+		}
+		totalBytes += bytes
+
+		copy(leafBuf[:32], v.Hash[:])
+		if v.Remember {
+			leafBuf[32] = 1
+		}
+		bytes, err = w.Write(leafBuf[:])
+		if err != nil {
+			return bytes, err
+		}
+		totalBytes += bytes
+	}
+
+	return totalBytes, nil
+}
+
+// Read reads the pollard from the reader into the map pollard variable.
+func (m *MapPollard) Read(r io.Reader) (int, error) {
+	totalBytes := 0
+
+	var buf [8]byte
+
+	// Read the total rows.
+	bytes, err := r.Read(buf[:1])
+	if err != nil {
+		return totalBytes, err
+	}
+	m.TotalRows = buf[0]
+	totalBytes += bytes
+
+	// Read the number of leaves.
+	bytes, err = r.Read(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+	m.NumLeaves = binary.LittleEndian.Uint64(buf[:])
+
+	// Read the count for the cache leaf elements in the map.
+	bytes, err = r.Read(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+	numCachedLeaves := binary.LittleEndian.Uint64(buf[:])
+
+	// Read elements and put them in the map.
+	m.CachedLeaves = make(map[Hash]uint64, numCachedLeaves)
+	var hash Hash
+	for i := 0; i < int(numCachedLeaves); i++ {
+		read, err := r.Read(hash[:])
+		if err != nil {
+			return totalBytes, err
+		}
+		totalBytes += read
+
+		// Read the number of leaves.
+		bytes, err = r.Read(buf[:])
+		if err != nil {
+			return totalBytes, err
+		}
+		totalBytes += bytes
+		m.CachedLeaves[hash] = binary.LittleEndian.Uint64(buf[:])
+	}
+
+	// Read the count for the node elements in the map.
+	bytes, err = r.Read(buf[:])
+	if err != nil {
+		return totalBytes, err
+	}
+	totalBytes += bytes
+	nodeCount := binary.LittleEndian.Uint64(buf[:])
+
+	m.Nodes = make(map[uint64]Leaf, nodeCount)
+	var leafBuf [33]byte
+	for i := 0; i < int(nodeCount); i++ {
+		bytes, err := r.Read(buf[:])
+		if err != nil {
+			return bytes, err
+		}
+		totalBytes += bytes
+		position := binary.LittleEndian.Uint64(buf[:])
+
+		read, err := r.Read(leafBuf[:])
+		if err != nil {
+			return totalBytes, err
+		}
+		totalBytes += read
+
+		var hash Hash
+		copy(hash[:], leafBuf[:32])
+		leaf := Leaf{Hash: hash, Remember: leafBuf[32] == 1}
+
+		m.Nodes[position] = leaf
+
+	}
+
+	// Sanity check.
+	leafHashes := make([]Hash, 0, len(m.CachedLeaves))
+	for k, v := range m.CachedLeaves {
+		leaf, found := m.Nodes[v]
+		if !found {
+			return totalBytes,
+				fmt.Errorf("Corrupted pollard. Missing cached leaf at %d", v)
+		}
+
+		if k != leaf.Hash {
+			return totalBytes,
+				fmt.Errorf("Corrupted pollard. Pos %d cached hash: %s, but have %s",
+					v, k, leaf.Hash)
+		}
+
+		leafHashes = append(leafHashes, k)
+	}
+
+	return totalBytes, nil
+}

--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -231,6 +231,8 @@ func FuzzMapPollardChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// simulate blocks with simchain
 		sc := newSimChainWithSeed(duration, seed)
 
@@ -362,6 +364,8 @@ func FuzzMapPollardWriteAndRead(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// simulate blocks with simchain

--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -1,0 +1,422 @@
+package utreexo
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+// Assert that MapPollard implements the UtreexoTest interface.
+var _ UtreexoTest = (*MapPollard)(nil)
+
+// cachedMapToString returns the cached map as a string.
+//
+// Implements the UtreexoTest interface.
+func (p *MapPollard) cachedMapToString() string {
+	return fmt.Sprintf("%v", p.CachedLeaves)
+}
+
+// nodeMapToString returns "n/a" as map pollard doesn't have a node map.
+func (m *MapPollard) nodeMapToString() string {
+	return "n/a"
+}
+
+// rootToString returns the roots as a string.
+func (m *MapPollard) rootToString() string {
+	return printHashes(m.GetRoots())
+}
+
+// sanityCheck checks that:
+// 1: Unneeded nodes aren't cached.
+// 2: Needed nodes for the cached leaves are cached.
+// 3: Cached proof hashes up to the roots.
+func (m *MapPollard) sanityCheck() error {
+	err := m.checkCachedNodesAreRemembered()
+	if err != nil {
+		return err
+	}
+
+	err = m.checkProofNodes()
+	if err != nil {
+		return err
+	}
+
+	err = m.checkHashes()
+	if err != nil {
+		return err
+	}
+
+	return m.checkPruned()
+}
+
+// checkCachedNodesAreRemembered checks that cached leaves are present in m.Nodes and that they're
+// marked to be remembered.
+func (m *MapPollard) checkCachedNodesAreRemembered() error {
+	for k, v := range m.CachedLeaves {
+		leaf, found := m.Nodes[v]
+		if !found {
+			return fmt.Errorf("Cached node of %s at pos %d not cached in m.Nodes", k, v)
+		}
+
+		if leaf.Remember == false {
+			return fmt.Errorf("Cached node of %s at pos %d not marked as remembered in m.Nodes", k, v)
+		}
+	}
+
+	return nil
+}
+
+// checkPruned checks that unneeded nodes aren't cached.
+func (m *MapPollard) checkPruned() error {
+	neededPos := make(map[uint64]struct{})
+	for _, v := range m.CachedLeaves {
+		neededPos[v] = struct{}{}
+
+		needs, computables := proofPositions([]uint64{v}, m.NumLeaves, m.TotalRows)
+		for _, need := range needs {
+			neededPos[need] = struct{}{}
+		}
+
+		for _, computable := range computables {
+			neededPos[computable] = struct{}{}
+		}
+	}
+
+	for _, pos := range rootPositions(m.NumLeaves, m.TotalRows) {
+		neededPos[pos] = struct{}{}
+	}
+
+	for k, v := range m.Nodes {
+		_, found := neededPos[k]
+		if !found {
+			return fmt.Errorf("Have node %s at pos %d in map "+
+				"even though it's not needed.\nCachedLeaves:\n%v\nm.Nodes:\n%v\n",
+				v, k, m.CachedLeaves, m.Nodes)
+		}
+	}
+
+	return nil
+}
+
+// checkProofNodes checks that all the proof positions needed to cache a proof exists in the map
+// of nodes.
+func (m *MapPollard) checkProofNodes() error {
+	// Sanity check.
+	for k, v := range m.CachedLeaves {
+		leaf, found := m.Nodes[v]
+		if !found {
+			return fmt.Errorf("Corrupted pollard. Missing cached leaf %s at %d", k, v)
+		}
+
+		if k != leaf.Hash {
+			return fmt.Errorf("Corrupted pollard. Pos %d cached hash: %s, but have %s",
+				v, k, leaf.Hash)
+		}
+
+		proofPos := proofPosition(v, m.NumLeaves, m.TotalRows)
+		for _, pos := range proofPos {
+			_, found := m.Nodes[pos]
+			if !found {
+				return fmt.Errorf("Corrupted pollard. Missing pos %d "+
+					"needed for proving %d", pos, v)
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkHashes checks that the leaves correctly hash up to the roots. Returns an error if
+// any of the roots or the intermediate nodes don't match up with the calculated hashes.
+func (m *MapPollard) checkHashes() error {
+	if len(m.CachedLeaves) == 0 {
+		return nil
+	}
+
+	leafHashes := make([]Hash, 0, len(m.CachedLeaves))
+	for leafHash := range m.CachedLeaves {
+		leafHashes = append(leafHashes, leafHash)
+	}
+
+	proof, err := m.Prove(leafHashes)
+	if err != nil {
+		return err
+	}
+
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		for i := range proof.Targets {
+			proof.Targets[i] = translatePos(proof.Targets[i], m.TotalRows, treeRows(m.NumLeaves))
+		}
+	}
+
+	haveRoots, rootPositions := m.getRoots()
+	rootIndexes, err := Verify(Stump{Roots: haveRoots, NumLeaves: m.NumLeaves}, leafHashes, proof)
+	if err != nil {
+		return fmt.Errorf("Failed to verify proof:\n%s\ndelHashes:\n%s\nerr: %v\n", proof.String(), printHashes(leafHashes), err)
+	}
+
+	// Check roots.
+	intermediate, gotRoots := calculateHashes(m.NumLeaves, leafHashes, proof)
+	if len(gotRoots) != len(rootIndexes) {
+		return fmt.Errorf("expected %d calculated roots but got %d", len(gotRoots), len(rootIndexes))
+	}
+
+	for i, rootIdx := range rootIndexes {
+		if haveRoots[rootIdx] != gotRoots[i] {
+			return fmt.Errorf("For root position %d, calculated %s but have %s",
+				rootPositions[i], hex.EncodeToString(gotRoots[i][:]),
+				hex.EncodeToString(haveRoots[rootIdx][:]))
+		}
+	}
+
+	// Check all intermediate nodes.
+	for i, pos := range intermediate.positions {
+		haveNode, found := m.Nodes[pos]
+		if !found {
+			continue
+		}
+		gotHash := intermediate.hashes[i]
+
+		if haveNode.Hash != gotHash {
+			return fmt.Errorf("For position %d, calculated %s but have %s",
+				pos, hex.EncodeToString(gotHash[:]), hex.EncodeToString(haveNode.Hash[:]))
+		}
+	}
+
+	return nil
+}
+
+// checkEqualProof checks that the two proofs are the same.
+func (p *Proof) checkEqualProof(other Proof) error {
+	if len(other.Targets) != len(p.Targets) {
+		return fmt.Errorf("Have %d targets but other has %d targets. mine: %v, other: %v",
+			len(p.Targets), len(other.Targets), p.Targets, other.Targets)
+	}
+
+	for i := range p.Targets {
+		if p.Targets[i] != other.Targets[i] {
+			return fmt.Errorf("At idx %d have %d but other has %d. sorted mine: %v, sorted other: %v",
+				i, p.Targets[i], other.Targets[i], p.Targets, other.Targets)
+		}
+	}
+
+	if len(other.Proof) != len(p.Proof) {
+		return fmt.Errorf("Have %d proof but other has %d proof.\nMine:\n%s\nother:\n%s\n",
+			len(p.Proof), len(other.Proof), printHashes(p.Proof), printHashes(other.Proof))
+	}
+
+	for i := range p.Proof {
+		if p.Proof[i] != other.Proof[i] {
+			return fmt.Errorf("At idx %d have %s but other has %s.\nMine:\n%s\nother:\n%s\n",
+				i, p.Proof[i], other.Proof[i], printHashes(p.Proof), printHashes(other.Proof))
+		}
+	}
+
+	return nil
+}
+
+func FuzzMapPollardChain(f *testing.F) {
+	var tests = []struct {
+		numAdds  uint32
+		duration uint32
+		seed     int64
+	}{
+		{3, 0x07, 0x07},
+	}
+	for _, test := range tests {
+		f.Add(test.numAdds, test.duration, test.seed)
+	}
+
+	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		// simulate blocks with simchain
+		sc := newSimChainWithSeed(duration, seed)
+
+		m := NewMapPollard()
+		if numAdds&1 == 1 {
+			m.TotalRows = 50
+		}
+		full := NewAccumulator(true)
+
+		var totalAdds, totalDels int
+		for b := 0; b <= 50; b++ {
+			adds, _, delHashes := sc.NextBlock(numAdds)
+			totalAdds += len(adds)
+			totalDels += len(delHashes)
+
+			expectProof, err := full.Prove(delHashes)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = m.Verify(delHashes, expectProof, true)
+			if err != nil {
+				t.Fatalf("%v\nproving delHashes:\nproof:\n%s\n%s\nmap:\n%s\nfull:\n%s\n",
+					err, printHashes(delHashes), expectProof.String(),
+					m.String(), full.String())
+			}
+
+			proof, err := m.Prove(delHashes)
+			if err != nil {
+				t.Fatalf("FuzzMapPollardChain fail at block %d. Couldn't prove\n%s\nError: %v",
+					b, printHashes(delHashes), err)
+			}
+
+			err = proof.checkEqualProof(expectProof)
+			if err != nil {
+				t.Fatalf("\nFor delhashes: %v\nexpected proof:\n%s\ngot:\n%s\nerr: %v\n"+
+					"maptreexo:\n%s\nfull:\n%s\n",
+					printHashes(delHashes), expectProof.String(), proof.String(), err,
+					m.String(), full.String())
+			}
+
+			for _, target := range proof.Targets {
+				fetch := target
+				if m.TotalRows != treeRows(m.NumLeaves) {
+					fetch = translatePos(fetch, treeRows(m.NumLeaves), m.TotalRows)
+				}
+				hash := m.GetHash(fetch)
+				if hash == empty {
+					t.Fatalf("FuzzMapPollardChain doesn't have the hash "+
+						"for %d at block %d.", target, b)
+				}
+			}
+
+			err = m.Modify(adds, delHashes, proof)
+			if err != nil {
+				t.Fatalf("FuzzMapPollardChain fail at block %d. Error: %v", b, err)
+			}
+
+			err = full.Modify(adds, delHashes, proof)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cachedHashes := make([]Hash, 0, len(m.CachedLeaves))
+			leafHashes := make([]Hash, 0, len(m.CachedLeaves))
+			for hash := range m.CachedLeaves {
+				cachedHashes = append(cachedHashes, hash)
+				leafHashes = append(leafHashes, hash)
+			}
+
+			if !reflect.DeepEqual(cachedHashes, leafHashes) {
+				err := fmt.Errorf("Fail at block %d. For cachedLeaves of %v\ngot cachedHashes:\n%s\n"+
+					"leafHashes:\n%s\nmaptreexo:\n%s\nfull:\n%s\n",
+					b, m.CachedLeaves, printHashes(cachedHashes), printHashes(leafHashes),
+					m.String(), full.String())
+				t.Fatal(err)
+			}
+
+			cachedProofExpect, err := full.Prove(cachedHashes)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cachedProof, err := m.Prove(leafHashes)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if m.TotalRows != treeRows(m.NumLeaves) {
+				for i := range cachedProof.Targets {
+					cachedProof.Targets[i] = translatePos(
+						cachedProof.Targets[i], m.TotalRows, treeRows(m.NumLeaves))
+				}
+			}
+
+			err = cachedProof.checkEqualProof(cachedProofExpect)
+			if err != nil {
+				t.Fatalf("\nFor delhashes: %v\nexpected proof:\n%s\ngot:\n%s\nerr: %v\n"+
+					"maptreexo:\n%s\nfull:\n%s\n",
+					printHashes(cachedHashes), cachedProofExpect.String(), cachedProof.String(),
+					err, m.String(), full.String())
+			}
+
+			fullRoots := full.GetRoots()
+			mapRoots := m.GetRoots()
+			if !reflect.DeepEqual(fullRoots, mapRoots) {
+				t.Fatalf("Roots differ. expected:\n%s\nbut got:\n%s\nfull:\n%s\nmap:\n%s\n",
+					printHashes(fullRoots), printHashes(mapRoots), full.String(), m.String())
+			}
+
+			err = m.sanityCheck()
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+func FuzzMapPollardWriteAndRead(f *testing.F) {
+	var tests = []struct {
+		numAdds  uint32
+		duration uint32
+		seed     int64
+	}{
+		{3, 0x07, 0x07},
+	}
+	for _, test := range tests {
+		f.Add(test.numAdds, test.duration, test.seed)
+	}
+
+	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		rand.Seed(seed)
+
+		// simulate blocks with simchain
+		sc := newSimChainWithSeed(duration, seed)
+
+		m := NewMapPollard()
+		for b := 0; b <= 20; b++ {
+			adds, durations, delHashes := sc.NextBlock(numAdds)
+			for i, duration := range durations {
+				if duration != 0 {
+					adds[i].Remember = true
+				}
+			}
+
+			proof, err := m.Prove(delHashes)
+			if err != nil {
+				t.Fatalf("FuzzWriteAndRead fail at block %d. Error: %v", b, err)
+			}
+
+			err = m.Modify(adds, delHashes, proof)
+			if err != nil {
+				t.Fatalf("FuzzWriteAndRead fail at block %d. Error: %v", b, err)
+			}
+		}
+		err := m.checkHashes()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		wroteBytes, err := m.Write(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if wroteBytes != len(buf.Bytes()) {
+			t.Fatalf("FuzzWriteAndRead Fail. Wrote %d but serializeSize got %d",
+				wroteBytes, len(buf.Bytes()))
+		}
+
+		m1 := NewMapPollard()
+
+		// Restore from the buffer.
+		readBytes, err := m1.Read(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if readBytes != wroteBytes {
+			t.Fatalf("FuzzWriteAndRead Fail. Wrote %d but read %d", readBytes, wroteBytes)
+		}
+
+		// Check that the hashes of the roots are correct.
+		err = m1.checkHashes()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -13,6 +13,13 @@ import (
 // Assert that Pollard implements the UtreexoTest interface.
 var _ UtreexoTest = (*Pollard)(nil)
 
+// cachedMapToString returns "n/a" as it's not present in Pollard
+//
+// Implements the UtreexoTest interface.
+func (p *Pollard) cachedMapToString() string {
+	return "n/a"
+}
+
 // nodeMapToString returns the node map as a string.
 //
 // Implements the UtreexoTest interface.
@@ -162,11 +169,14 @@ func testUndo(t *testing.T, utreexo UtreexoTest) {
 		case *Pollard:
 			v := NewAccumulator(true)
 			utreexo = &v
+		case *MapPollard:
+			v := NewMapPollard()
+			utreexo = &v
 		}
 		adds := make([]Leaf, len(test.startAdds))
 		for i := range adds {
 			hash := test.startAdds[i]
-			adds[i] = Leaf{Hash: hash}
+			adds[i] = Leaf{Hash: hash, Remember: true}
 		}
 
 		// Create the initial starting off pollard.
@@ -272,6 +282,7 @@ func TestUndo(t *testing.T) {
 	t.Parallel()
 
 	testUndo(t, &Pollard{})
+	testUndo(t, &MapPollard{})
 }
 
 // checkHashes moves down the tree and calculates the parent hash from the children.
@@ -573,6 +584,9 @@ func FuzzModify(f *testing.F) {
 	f.Fuzz(func(t *testing.T, startLeaves uint32, modifyAdds uint32, delCount uint32) {
 		p := NewAccumulator(true)
 		fuzzModify(t, &p, startLeaves, modifyAdds, delCount)
+
+		p1 := NewMapPollard()
+		fuzzModify(t, &p1, startLeaves, modifyAdds, delCount)
 	})
 }
 
@@ -589,6 +603,7 @@ func fuzzModify(t *testing.T, p UtreexoTest, startLeaves, modifyAdds, delCount u
 	}
 	beforeStr := p.String()
 	beforeMap := p.nodeMapToString()
+	beforeCached := p.cachedMapToString()
 
 	modifyLeaves, _, _ := getAddsAndDels(uint32(p.GetNumLeaves()), modifyAdds, 0)
 	err = p.Modify(modifyLeaves, delHashes, Proof{Targets: delTargets})
@@ -597,6 +612,7 @@ func fuzzModify(t *testing.T, p UtreexoTest, startLeaves, modifyAdds, delCount u
 	}
 	afterStr := p.String()
 	afterMap := p.nodeMapToString()
+	afterCached := p.cachedMapToString()
 
 	err = p.sanityCheck()
 	if err != nil {
@@ -618,7 +634,9 @@ func fuzzModify(t *testing.T, p UtreexoTest, startLeaves, modifyAdds, delCount u
 			"\nmodifyDels:\n%s"+
 			"\ndel targets:\n %v"+
 			"\nnodemap before modify:\n %s"+
-			"\nnodemap after modify:\n %s",
+			"\nnodemap after modify:\n %s"+
+			"\ncachedmap before modify:\n %s"+
+			"\ncachedmap after modify:\n %s",
 			err,
 			beforeStr,
 			afterStr,
@@ -628,7 +646,9 @@ func fuzzModify(t *testing.T, p UtreexoTest, startLeaves, modifyAdds, delCount u
 			printHashes(delHashes),
 			delTargets,
 			beforeMap,
-			afterMap)
+			afterMap,
+			beforeCached,
+			afterCached)
 		t.Fatal(err)
 	}
 }
@@ -732,6 +752,7 @@ func FuzzUndo(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, startLeaves uint8, modifyAdds uint8, delCount uint8) {
 		fuzzUndo(t, &Pollard{}, startLeaves, modifyAdds, delCount)
+		fuzzUndo(t, &MapPollard{}, startLeaves, modifyAdds, delCount)
 	})
 }
 
@@ -745,6 +766,9 @@ func fuzzUndo(t *testing.T, p UtreexoTest, startLeaves uint8, modifyAdds uint8, 
 	switch p.(type) {
 	case *Pollard:
 		v := NewAccumulator(true)
+		p = &v
+	case *MapPollard:
+		v := NewMapPollard()
 		p = &v
 	}
 	// Create the starting off pollard.
@@ -913,13 +937,27 @@ func FuzzUndoChain(f *testing.F) {
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
 		// We have to do this because the fuzz will give process hung or
 		// terminated unexpectedly error.
+		if numAdds > 1500 {
+			return
+		}
 		numBlocks := uint32(100)
-		if numAdds > 500 {
+		if numAdds > 1000 {
+			numBlocks = 20
+		} else if numAdds > 500 {
 			numBlocks = 30
+		} else if numAdds > 100 {
+			numBlocks = 50
 		}
 
-		p := NewAccumulator(true)
-		fuzzUndoChain(t, &p, numBlocks, numAdds, duration, seed)
+		// Only run either or since if we run both the fuzz test will give process
+		// hung or terminated unexpectedly error.
+		if numAdds&1 == 1 {
+			p := NewAccumulator(true)
+			fuzzUndoChain(t, &p, numBlocks, numAdds, duration, seed)
+		} else {
+			p1 := NewMapPollard()
+			fuzzUndoChain(t, &p1, numBlocks, numAdds, duration, seed)
+		}
 	})
 }
 
@@ -1022,6 +1060,11 @@ func fuzzUndoChain(t *testing.T, p UtreexoTest, blockCount, numAdds, duration ui
 			t.Fatal(err)
 		}
 
+		err = p.sanityCheck()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		// Undo the last 10 modifies and re-do them.
 		if b%10 == 9 {
 			for i := 9; i >= 0; i-- {
@@ -1030,6 +1073,12 @@ func fuzzUndoChain(t *testing.T, p UtreexoTest, blockCount, numAdds, duration ui
 				copy(copyProof.Proof, undoData[i].proof.Proof)
 
 				err := p.Undo(uint64(len(undoData[i].adds)), copyProof, undoData[i].hashes, undoData[i].prevRoots)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Sanity check after the undo.
+				err = p.sanityCheck()
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1069,40 +1118,31 @@ func fuzzUndoChain(t *testing.T, p UtreexoTest, blockCount, numAdds, duration ui
 				}
 			}
 
-			// Sanity check after the undos.
-			err = p.sanityCheck()
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			// Undo the undos.
 			for i := 0; i < 10; i++ {
-				adds, delHashes := undoData[i].adds, undoData[i].hashes
+				adds, delHashes, bp := undoData[i].adds, undoData[i].hashes, undoData[i].proof
 
-				bp := undoData[i].proof
-				err = p.Verify(delHashes, bp, true)
-				if err != nil {
-					t.Fatal(err)
+				switch v := p.(type) {
+				case *Pollard:
+				case *MapPollard:
+					v.Ingest(delHashes, bp)
+					err = p.sanityCheck()
+					if err != nil {
+						t.Fatal(err)
+					}
 				}
 				err = p.Modify(adds, delHashes, bp)
 				if err != nil {
 					t.Fatalf("FuzzUndoChain fail at block %d. Error: %v", b, err)
 				}
+				err = p.sanityCheck()
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
-			// Sanity check after undoing the undos.
-			err = p.sanityCheck()
-			if err != nil {
-				t.Fatal(err)
-			}
 			undoData = undoData[:0]
 		}
-	}
-
-	// Sanity check after it's all finished.
-	err := p.sanityCheck()
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -582,6 +582,8 @@ func FuzzModify(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, modifyAdds uint32, delCount uint32) {
+		t.Parallel()
+
 		p := NewAccumulator(true)
 		fuzzModify(t, &p, startLeaves, modifyAdds, delCount)
 
@@ -666,6 +668,8 @@ func FuzzModifyChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// simulate blocks with simchain
 		sc := newSimChainWithSeed(duration, seed)
 
@@ -751,6 +755,8 @@ func FuzzUndo(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint8, modifyAdds uint8, delCount uint8) {
+		t.Parallel()
+
 		fuzzUndo(t, &Pollard{}, startLeaves, modifyAdds, delCount)
 		fuzzUndo(t, &MapPollard{}, startLeaves, modifyAdds, delCount)
 	})
@@ -935,6 +941,8 @@ func FuzzUndoChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// We have to do this because the fuzz will give process hung or
 		// terminated unexpectedly error.
 		if numAdds > 1500 {
@@ -1159,6 +1167,8 @@ func FuzzWriteAndRead(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// simulate blocks with simchain

--- a/prove_test.go
+++ b/prove_test.go
@@ -131,6 +131,8 @@ func FuzzGetMissingPositions(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, delCount uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// It'll error out if we try to delete more than we have. >= since we want
@@ -232,6 +234,8 @@ func FuzzAddProof(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, delCount uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// It'll error out if we try to delete more than we have. >= since we want
@@ -331,6 +335,8 @@ func FuzzUpdateProofRemove(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, delCount uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// It'll error out if we try to delete more than we have. >= since we want
@@ -483,6 +489,8 @@ func FuzzUpdateProofAdd(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves, delCount, addCount uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// It'll error out if we try to delete more than we have. >= since we want
@@ -582,6 +590,8 @@ func FuzzModifyProofChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// simulate blocks with simchain
 		sc := newSimChainWithSeed(duration, seed)
 
@@ -751,6 +761,8 @@ func FuzzGetProofSubset(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, delCount uint32, seed int64) {
+		t.Parallel()
+
 		rand.Seed(seed)
 
 		// It'll error out if we try to delete more than we have. >= since we want
@@ -874,6 +886,8 @@ func FuzzUndoProofChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// simulate blocks with simchain
 		sc := newSimChainWithSeed(duration, seed)
 
@@ -1132,6 +1146,8 @@ func FuzzUndoProof(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, seed int64, startLeaves uint8, modifyAdds uint8, delCount uint8) {
+		t.Parallel()
+
 		rand.Seed(seed)
 		// delCount must be less than the current number of leaves.
 		if delCount > startLeaves {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,8 @@
 # The script does automatic checking on a Go package and its sub-packages.
 set -ex
 
-env GORACE="halt_on_error=1" go test -race -covermode atomic -coverprofile=profile.cov ./...
+env GORACE="halt_on_error=1" go test -race
+env GORACE="halt_on_error=1" go test -covermode atomic -coverprofile=profile.cov ./...
 
 # Automatic checks
 golangci-lint run --disable-all --deadline=10m \

--- a/stump_test.go
+++ b/stump_test.go
@@ -45,6 +45,8 @@ func FuzzStump(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, startLeaves uint32, modifyAdds uint32, delCount uint32, seed int64) {
+		t.Parallel()
+
 		// Set seed to make sure the test is reproducible.
 		rand.Seed(seed)
 
@@ -145,6 +147,8 @@ func FuzzStumpChain(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, numAdds, duration uint32, seed int64) {
+		t.Parallel()
+
 		// simulate blocks with simchain
 		sc := newSimChainWithSeed(duration, seed)
 

--- a/testdata/fuzz/FuzzMapPollardChain/0277b007269552ed619c76d885af3d9f1e62cd0d36c4df550d8d19485a9dc663
+++ b/testdata/fuzz/FuzzMapPollardChain/0277b007269552ed619c76d885af3d9f1e62cd0d36c4df550d8d19485a9dc663
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(15)
+uint32(7)
+int64(-47)

--- a/testdata/fuzz/FuzzMapPollardChain/03e2325a34949f9822769ba28dcedf127adc601d6ec70c90fd7e51e467a3f47a
+++ b/testdata/fuzz/FuzzMapPollardChain/03e2325a34949f9822769ba28dcedf127adc601d6ec70c90fd7e51e467a3f47a
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(5)
+int64(-183)

--- a/testdata/fuzz/FuzzMapPollardChain/046784d3243a6a9178c9eb1748f1ff88646023d73c908ca424e4319d4b8ba068
+++ b/testdata/fuzz/FuzzMapPollardChain/046784d3243a6a9178c9eb1748f1ff88646023d73c908ca424e4319d4b8ba068
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(45)
+uint32(5)
+int64(-2)

--- a/testdata/fuzz/FuzzMapPollardChain/05dc0bba5a6780b9d4f86e94f8bfbf69ac08085ff235ec72192cd14af2e2bb41
+++ b/testdata/fuzz/FuzzMapPollardChain/05dc0bba5a6780b9d4f86e94f8bfbf69ac08085ff235ec72192cd14af2e2bb41
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(2)
+uint32(3)
+int64(-11)

--- a/testdata/fuzz/FuzzMapPollardChain/1caa842f9a8d6b85f126e1f918c2081caa5001273e86f401dc9cb9de053db199
+++ b/testdata/fuzz/FuzzMapPollardChain/1caa842f9a8d6b85f126e1f918c2081caa5001273e86f401dc9cb9de053db199
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(4)
+int64(130)

--- a/testdata/fuzz/FuzzMapPollardChain/1d2a55994ca76e3331696cbdc5798ce17fe0f31bd0be1d73ad506cf46012aa74
+++ b/testdata/fuzz/FuzzMapPollardChain/1d2a55994ca76e3331696cbdc5798ce17fe0f31bd0be1d73ad506cf46012aa74
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(36)
+uint32(7)
+int64(7)

--- a/testdata/fuzz/FuzzMapPollardChain/2c213b8a95e3c2619077b62725a03ce4aeed7ecc169d8e75e26837ca0c1ff1eb
+++ b/testdata/fuzz/FuzzMapPollardChain/2c213b8a95e3c2619077b62725a03ce4aeed7ecc169d8e75e26837ca0c1ff1eb
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(88)
+uint32(3)
+int64(-84)

--- a/testdata/fuzz/FuzzMapPollardChain/328db7235c8ef73ca91251ab3e99b0729f7f26d597c6ddafaf6128a6a6da15b7
+++ b/testdata/fuzz/FuzzMapPollardChain/328db7235c8ef73ca91251ab3e99b0729f7f26d597c6ddafaf6128a6a6da15b7
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(2)
+int64(7)

--- a/testdata/fuzz/FuzzMapPollardChain/7fe0d05c44126aba4f2464ac50b666aa07464aa09523b65190ad46e19e23c3d8
+++ b/testdata/fuzz/FuzzMapPollardChain/7fe0d05c44126aba4f2464ac50b666aa07464aa09523b65190ad46e19e23c3d8
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(337)
+int64(-43)

--- a/testdata/fuzz/FuzzMapPollardChain/844bdff170e8227ce2c516465f4d4996c36d281a41275c144391e508d6cdc045
+++ b/testdata/fuzz/FuzzMapPollardChain/844bdff170e8227ce2c516465f4d4996c36d281a41275c144391e508d6cdc045
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(8)
+uint32(7)
+int64(-215)

--- a/testdata/fuzz/FuzzMapPollardChain/c3b20dbf0836e7e641cbc1a18b9992010f50f5780da8fe791968532a35396ff2
+++ b/testdata/fuzz/FuzzMapPollardChain/c3b20dbf0836e7e641cbc1a18b9992010f50f5780da8fe791968532a35396ff2
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(5)
+uint32(209)
+int64(88)

--- a/testdata/fuzz/FuzzMapPollardChain/c9bb5d2803a1b0647823148daedd3acdb34264464268a8a4cb24c95fdfd00ebb
+++ b/testdata/fuzz/FuzzMapPollardChain/c9bb5d2803a1b0647823148daedd3acdb34264464268a8a4cb24c95fdfd00ebb
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(206)
+uint32(1)
+int64(27)

--- a/testdata/fuzz/FuzzMapPollardChain/d2aff0d821ce36a206fa9a0f7d4287985604ab293ffb58ad23ca72a8221359e8
+++ b/testdata/fuzz/FuzzMapPollardChain/d2aff0d821ce36a206fa9a0f7d4287985604ab293ffb58ad23ca72a8221359e8
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(3)
+int64(245)

--- a/testdata/fuzz/FuzzMapPollardChain/d68491f5ecc87132645e6e22d509316aadf9a472fa5fbee01e03e8e9222bceb1
+++ b/testdata/fuzz/FuzzMapPollardChain/d68491f5ecc87132645e6e22d509316aadf9a472fa5fbee01e03e8e9222bceb1
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(88)
+uint32(82)
+int64(-84)

--- a/testdata/fuzz/FuzzMapPollardWriteAndRead/0014b4d2c6db16762e137bd17970884faa1d3e86e742d2a791792841b119b48b
+++ b/testdata/fuzz/FuzzMapPollardWriteAndRead/0014b4d2c6db16762e137bd17970884faa1d3e86e742d2a791792841b119b48b
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(48)
+int64(7)

--- a/testdata/fuzz/FuzzMapPollardWriteAndRead/20288955612712f534b09dd45ec0cca0d9b0dc02c0540001be16c8cea5be913a
+++ b/testdata/fuzz/FuzzMapPollardWriteAndRead/20288955612712f534b09dd45ec0cca0d9b0dc02c0540001be16c8cea5be913a
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(7)
+int64(-39)

--- a/testdata/fuzz/FuzzMapPollardWriteAndRead/453cb69a910db73d6e332f696a4700c9c38de686a87d0540149402054b1c08e3
+++ b/testdata/fuzz/FuzzMapPollardWriteAndRead/453cb69a910db73d6e332f696a4700c9c38de686a87d0540149402054b1c08e3
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(83)
+uint32(97)
+int64(-72)

--- a/testdata/fuzz/FuzzMapPollardWriteAndRead/6d942796d36626f0a1acb238ad75bef4e5a1217316912dc8c42a14aa4f87de21
+++ b/testdata/fuzz/FuzzMapPollardWriteAndRead/6d942796d36626f0a1acb238ad75bef4e5a1217316912dc8c42a14aa4f87de21
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(1)
+int64(99)

--- a/testdata/fuzz/FuzzMapPollardWriteAndRead/9f2d15b76d7213835dd96dc8b9ff408800b3dcfc2d4f83d03f8caace5a1ca461
+++ b/testdata/fuzz/FuzzMapPollardWriteAndRead/9f2d15b76d7213835dd96dc8b9ff408800b3dcfc2d4f83d03f8caace5a1ca461
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(2)
+uint32(7)
+int64(7)

--- a/testdata/fuzz/FuzzUndoChain/16cca5111945ecd35b6b2b7afae1f334973db385bfedfe3e93e814596747056d
+++ b/testdata/fuzz/FuzzUndoChain/16cca5111945ecd35b6b2b7afae1f334973db385bfedfe3e93e814596747056d
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(3)
+int64(-244)

--- a/testdata/fuzz/FuzzUndoChain/2f8f2ff9a37d8d7fbaa1a4589723d0584051b7bc08089dfa8f6b767423a8ddf7
+++ b/testdata/fuzz/FuzzUndoChain/2f8f2ff9a37d8d7fbaa1a4589723d0584051b7bc08089dfa8f6b767423a8ddf7
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(492)
+uint32(44)
+int64(-34)

--- a/testdata/fuzz/FuzzUndoChain/4498e29d0b8eb08f85dd21dc0d050b735bd3e09f1a81eaf943a8020aab587cbe
+++ b/testdata/fuzz/FuzzUndoChain/4498e29d0b8eb08f85dd21dc0d050b735bd3e09f1a81eaf943a8020aab587cbe
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(499)
+uint32(23)
+int64(-34)

--- a/testdata/fuzz/FuzzUndoChain/712dc0fc864f7020168eb3f3c7d729ec6187bcfab55b4f5ceb2bb6a6d62d06ca
+++ b/testdata/fuzz/FuzzUndoChain/712dc0fc864f7020168eb3f3c7d729ec6187bcfab55b4f5ceb2bb6a6d62d06ca
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(442)
+uint32(27)
+int64(-28)

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProofPosition(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		position  uint64
 		numLeaves uint64
@@ -35,6 +37,8 @@ func TestProofPosition(t *testing.T) {
 }
 
 func TestInForest(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		position  uint64
 		numLeaves uint64
@@ -79,6 +83,8 @@ func TestInForest(t *testing.T) {
 }
 
 func TestRootPositions(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		numLeaves uint64
 		totalRows uint8
@@ -106,6 +112,8 @@ func TestRootPositions(t *testing.T) {
 }
 
 func TestIsRootPositionTotalRows(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		position  uint64
 		numLeaves uint64
@@ -140,6 +148,8 @@ func TestIsRootPositionTotalRows(t *testing.T) {
 }
 
 func TestIsRootPosition(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		position  uint64
 		numLeaves uint64


### PR DESCRIPTION
MapPollard implements a partial utreexo accumulator using only a
hashmap. The main use case is so that we can have a simpler structure to
use to test bitcoin p2p protocols without having to complete the partial
pollard capability.