### PR TITLE
prove: return error when proof is short

### DIFF
--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -159,7 +159,10 @@ func (m *MapPollard) checkHashes() error {
 	}
 
 	// Check roots.
-	intermediate, gotRoots := calculateHashes(m.NumLeaves, leafHashes, proof)
+	intermediate, gotRoots, err := calculateHashes(m.NumLeaves, leafHashes, proof)
+	if err != nil {
+		return err
+	}
 	if len(gotRoots) != len(rootIndexes) {
 		return fmt.Errorf("expected %d calculated roots but got %d", len(gotRoots), len(rootIndexes))
 	}

--- a/prove_test.go
+++ b/prove_test.go
@@ -414,7 +414,10 @@ func FuzzUpdateProofRemove(f *testing.F) {
 		cachedTargetsAndHash = subtractSortedHashAndPos(cachedTargetsAndHash, blockDelTargetsAndHash.positions, uint64Cmp)
 
 		// Update the cached proof with the block proof.
-		updated, _ := calculateHashes(p.NumLeaves, nil, blockProof)
+		updated, _, err := calculateHashes(p.NumLeaves, nil, blockProof)
+		if err != nil {
+			t.Fatal(err)
+		}
 		leafSubset.hashes = cachedProof.updateProofRemove(blockProof.Targets, leafSubset.hashes, updated, p.NumLeaves)
 
 		// Modify the pollard.

--- a/stump.go
+++ b/stump.go
@@ -77,7 +77,10 @@ func Verify(stump Stump, delHashes []Hash, proof Proof) ([]int, error) {
 			"hashes for those targets", len(proof.Targets), len(delHashes))
 	}
 
-	_, rootCandidates := calculateHashes(stump.NumLeaves, delHashes, proof)
+	_, rootCandidates, err := calculateHashes(stump.NumLeaves, delHashes, proof)
+	if err != nil {
+		return nil, err
+	}
 	rootIndexes := make([]int, 0, len(rootCandidates))
 	for i := range stump.Roots {
 		if len(rootCandidates) > len(rootIndexes) &&
@@ -109,7 +112,10 @@ func (s *Stump) del(delHashes []Hash, proof Proof) ([]Hash, []uint64, error) {
 	}
 
 	// Then calculate the modified roots.
-	intermediate, modifiedRoots := calculateHashes(s.NumLeaves, nil, proof)
+	intermediate, modifiedRoots, err := calculateHashes(s.NumLeaves, nil, proof)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(modifiedRoots) != len(rootIndexes) {
 		return nil, nil, fmt.Errorf("Stump update fail: expected %d modified roots but got %d",
 			len(rootIndexes), len(modifiedRoots))

--- a/stump_test.go
+++ b/stump_test.go
@@ -258,8 +258,11 @@ func checkUpdateData(updateData UpdateData, adds, delHashes, prevRoots []Hash, p
 	}
 
 	// Calculate the modified roots after the remove.
-	intermediate, roots := calculateHashes(updateData.PrevNumLeaves,
+	intermediate, roots, err := calculateHashes(updateData.PrevNumLeaves,
 		targetsWithHash.hashes, Proof{targetsWithHash.positions, proofWithPositions.hashes})
+	if err != nil {
+		return err
+	}
 
 	// Check that the intermidate hashes and positions are the same.
 	if !reflect.DeepEqual(intermediate, hashAndPos{updateData.NewDelPos, updateData.NewDelHash}) {


### PR DESCRIPTION
Previously the go runtime was able to throw a panic on an invalid proof if the proof length was not long enough. This is obviously undesirable and this commit now adds a check to make sure that the proof length cannot make the entire program panic.