### PR TITLE
mappollard: fix trimProof if condition

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -848,7 +848,7 @@ func (m *MapPollard) Ingest(delHashes []Hash, proof Proof) error {
 
 	// Calculate and ingest the proof.
 	proofPos, _ := proofPositions(hnp.positions, m.NumLeaves, m.TotalRows)
-	if treeRows(m.NumLeaves) > m.TotalRows {
+	if treeRows(m.NumLeaves) != m.TotalRows && len(proofPos) != len(proof.Proof) {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
 	}
 	for i, pos := range proofPos {


### PR DESCRIPTION
We're checking if the m.TotalRows is allocating more than what treeRows(m.NumLeaves) requires.  The comparison was incorrect and it's changed to != since the treeRows(m.NumLeaves) can never be smaller than m.TotalRows anyways.