### PR TITLE
pollard: add getleafhashpositions

### DIFF
--- a/pollard.go
+++ b/pollard.go
@@ -64,6 +64,22 @@ func (p *Pollard) GetTreeRows() uint8 {
 	return treeRows(p.NumLeaves)
 }
 
+// GetPositions returns the positions of the passed in leaf hashes. Any position that wasn't found
+// will be the default of 0.
+//
+// NOTE: only leaves are able to be fetched. Any non-leaf nodes will return as 0.
+func (p *Pollard) GetLeafPositions(hashes []Hash) []uint64 {
+	positions := make([]uint64, len(hashes))
+	for i := range positions {
+		polNode, found := p.NodeMap[hashes[i].mini()]
+		if found {
+			positions[i] = p.calculatePosition(polNode)
+		}
+	}
+
+	return positions
+}
+
 // Modify takes in the additions and deletions and updates the accumulator accordingly.
 //
 // NOTE Modify does NOT do any validation and assumes that all the positions of the leaves


### PR DESCRIPTION
GetLeafHashPositions provides a method for bridge nodes to fetch positions for the inputs of a transaction in the mempool.