### PR TITLE
stump: add fast case for rootsToDestroy

### DIFF
--- a/stump.go
+++ b/stump.go
@@ -217,6 +217,17 @@ func (s *Stump) add(adds []Hash) ([]Hash, []uint64, []uint64) {
 // rootsToDestory returns the empty roots that get written over after numAdds
 // amount of leaves have been added.
 func rootsToDestory(numAdds, numLeaves uint64, origRoots []Hash) []uint64 {
+	// Check if there are any empty roots. If there are not, return early.
+	exists := false
+	for _, root := range origRoots {
+		if root == empty {
+			exists = true
+		}
+	}
+	if !exists {
+		return []uint64{}
+	}
+
 	roots := make([]Hash, len(origRoots))
 	copy(roots, origRoots)
 


### PR DESCRIPTION
The byte comparsions happening in rootsToDestroy was expensive to do for every single add. Since empty roots are rare, having this early return saves on a lot of cpu cycles.