### PR TITLE
mappollard: increase the pre-allocated totalrows

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -38,7 +38,7 @@ func NewMapPollard() MapPollard {
 	return MapPollard{
 		CachedLeaves: make(map[Hash]uint64),
 		Nodes:        make(map[uint64]Leaf),
-		TotalRows:    50,
+		TotalRows:    63,
 	}
 }
 


### PR DESCRIPTION
The maximum amount of total rows that we can have is 2**64 as the max position we can have with uint64 is within the bounds of 2**64 utreexo tree. 50 is kind of a random number anyways, why not make it a max.