### PR TITLE
accumulator_interface: add GetLeafPosition to the interface

### DIFF
--- a/accumulator_interface.go
+++ b/accumulator_interface.go
@@ -25,6 +25,12 @@ type Utreexo interface {
 	// doesn't exist or if the position is not cached.
 	GetHash(position uint64) Hash
 
+	// GetLeafPosition returns the position for the given leaf hash. The boolean returns false if the
+	// hash wasn't found.
+	//
+	// NOTE It always returns false for any non-leaf hashes.
+	GetLeafPosition(Hash) (uint64, bool)
+
 	// GetNumLeaves returns the number of total additions the accumulator has ever had.
 	GetNumLeaves() uint64
 

--- a/mappollard.go
+++ b/mappollard.go
@@ -1230,6 +1230,15 @@ func (m *MapPollard) GetHash(pos uint64) Hash {
 	return leaf.Hash
 }
 
+// GetLeafPosition returns the position of the leaf for the given hash. Returns false if
+// the hash is not the hash of a leaf or if the hash wasn't found in the accumulator.
+func (m *MapPollard) GetLeafPosition(hash Hash) (uint64, bool) {
+	m.rwLock.RLock()
+	defer m.rwLock.RUnlock()
+
+	return m.CachedLeaves.Get(hash)
+}
+
 func (m *MapPollard) highestPos() uint64 {
 	totalRows := treeRows(m.NumLeaves)
 	pos := rootPosition(m.NumLeaves, totalRows, totalRows)

--- a/pollard.go
+++ b/pollard.go
@@ -67,20 +67,15 @@ func (p *Pollard) GetTreeRows() uint8 {
 	return treeRows(p.NumLeaves)
 }
 
-// GetPositions returns the positions of the passed in leaf hashes. Any position that wasn't found
-// will be the default of 0.
-//
-// NOTE: only leaves are able to be fetched. Any non-leaf nodes will return as 0.
-func (p *Pollard) GetLeafPositions(hashes []Hash) []uint64 {
-	positions := make([]uint64, len(hashes))
-	for i := range positions {
-		polNode, found := p.NodeMap[hashes[i].mini()]
-		if found {
-			positions[i] = p.calculatePosition(polNode)
-		}
+// GetLeafPosition returns the position of the leaf for the given hash. Returns false if
+// the hash is not the hash of a leaf or if the hash wasn't found in the accumulator.
+func (p *Pollard) GetLeafPosition(hash Hash) (uint64, bool) {
+	polNode, found := p.NodeMap[hash.mini()]
+	if !found {
+		return 0, false
 	}
 
-	return positions
+	return p.calculatePosition(polNode), true
 }
 
 // Modify takes in the additions and deletions and updates the accumulator accordingly.


### PR DESCRIPTION
The newly added interface will allow for bridge nodes to fetch positions for leaves so that the positions can be broadcast to utreexo peers.