### PR TITLE
mappollard: translate positions on GetLeafPosition

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -1263,7 +1263,16 @@ func (m *MapPollard) GetLeafPosition(hash Hash) (uint64, bool) {
 	m.rwLock.RLock()
 	defer m.rwLock.RUnlock()
 
-	return m.CachedLeaves.Get(hash)
+	pos, found := m.CachedLeaves.Get(hash)
+	if !found {
+		return 0, false
+	}
+
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		pos = translatePos(pos, m.TotalRows, treeRows(m.NumLeaves))
+	}
+
+	return pos, true
 }
 
 func (m *MapPollard) highestPos() uint64 {


### PR DESCRIPTION
The returned position from GetLeafPosition was the untranslated internal position, which is different from the actual position. Fixes the bug and adds a test.