### PR TITLE
utils: fix 32 bit system bug

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -429,8 +429,7 @@ func startPositionAtRow(row, forestRows uint8) uint64 {
 	// 2 << forestRows is 2 more than the max poisition
 	// to get the correct offset for a given row,
 	// subtract (2 << `row complement of forestRows`) from (2 << forestRows)
-	offset := (2 << forestRows) - (2 << (forestRows - row))
-	return uint64(offset)
+	return uint64(2<<forestRows) - (2 << (forestRows - row))
 }
 
 // maxPossiblePosAtRow returns the biggest position an accumulator can have for the


### PR DESCRIPTION
For startPositionAtRow, calculated offset variable was an int which was being casted to uint64. This would overflow on 32bit systems and so we make sure we always use uint64 and don't let the value be int.