### PR TITLE
mappollard: make sure to remove dangling empty root on add

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -339,6 +339,9 @@ func (m *MapPollard) addSingle(add Leaf) error {
 
 		// If the root is empty, then we move up the current node and all its children.
 		if node.Hash == empty {
+			// This root is overwritten by the add so remove it.
+			m.Nodes.Delete(rootPos)
+
 			// Move up the current node.
 			m.Nodes.Delete(position)
 			if add.Remember && pNode.Hash == add.Hash {


### PR DESCRIPTION
On add, when we're on hashing against a zombie root, sometimes that zombie root would stay dangling around and overwrite other nodes on moveUpDescendents. We make sure that we remove the zombie root to avoid this bug.