### PR TITLE
mappollard: translate position on GetHash

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -1256,6 +1256,9 @@ func (m *MapPollard) GetHash(pos uint64) Hash {
 	m.rwLock.RLock()
 	defer m.rwLock.RUnlock()
 
+	if m.TotalRows != treeRows(m.NumLeaves) {
+		pos = translatePos(pos, treeRows(m.NumLeaves), m.TotalRows)
+	}
 	leaf, _ := m.Nodes.Get(pos)
 	return leaf.Hash
 }


### PR DESCRIPTION
When calling GetHash, callers would do so through the position of the accumulator when it's the minimum amount of treerows possible. Since interally mappollard may have more rows allocated, make sure to translate the position.