### PR TITLE
utreexo: use `slices` from standard lib

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -625,7 +625,7 @@ func (m *MapPollard) remove(proof Proof, delHashes []Hash) error {
 	// Remove dels from the cached leaves.
 	m.uncacheLeaves(delHashes)
 
-	detwinedDels := copySortedFunc(proof.Targets, uint64Less)
+	detwinedDels := copySortedFunc(proof.Targets, uint64Cmp)
 	if m.TotalRows != treeRows(m.NumLeaves) {
 		detwinedDels = translatePositions(detwinedDels, treeRows(m.NumLeaves), m.TotalRows)
 	}
@@ -759,7 +759,7 @@ func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 
 	// Calculate the positions of the proofs and translate them if needed and
 	// then place in the proof hashes into the calculated positions.
-	sortedTargets := copySortedFunc(proof.Targets, uint64Less)
+	sortedTargets := copySortedFunc(proof.Targets, uint64Cmp)
 	proofPos, _ := proofPositions(sortedTargets, m.NumLeaves, treeRows(m.NumLeaves))
 	if treeRows(m.NumLeaves) != m.TotalRows {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
@@ -832,7 +832,7 @@ func (m *MapPollard) getRootsAfterDel(numAdds uint64, targets, prevRootPos []uin
 	prevRoots := make([]Hash, len(origPrevRoots))
 	copy(prevRoots, origPrevRoots)
 
-	detwined := deTwin(translatePositions(copySortedFunc(targets, uint64Less),
+	detwined := deTwin(translatePositions(copySortedFunc(targets, uint64Cmp),
 		treeRows(m.NumLeaves-numAdds), m.TotalRows), m.TotalRows)
 
 	for i := range detwined {
@@ -949,7 +949,7 @@ func (m *MapPollard) Prove(proveHashes []Hash) (Proof, error) {
 	}
 
 	// Sort targets first. Copy to avoid mutating the original.
-	targets := copySortedFunc(origTargets, uint64Less)
+	targets := copySortedFunc(origTargets, uint64Cmp)
 
 	// The positions of the hashes we need to prove the passed in targets.
 	proofPos, _ := proofPositions(targets, m.NumLeaves, m.TotalRows)
@@ -994,7 +994,7 @@ func (m *MapPollard) VerifyPartialProof(origTargets []uint64, delHashes, proofHa
 	defer m.rwLock.Unlock()
 
 	// Sort targets first. Copy to avoid mutating the original.
-	targets := copySortedFunc(origTargets, uint64Less)
+	targets := copySortedFunc(origTargets, uint64Cmp)
 
 	// Figure out what hashes at which positions are needed.
 	proofPositions, _ := proofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
@@ -1040,7 +1040,7 @@ func (m *MapPollard) GetMissingPositions(origTargets []uint64) []uint64 {
 	defer m.rwLock.RUnlock()
 
 	// Sort targets first. Copy to avoid mutating the original.
-	targets := copySortedFunc(origTargets, uint64Less)
+	targets := copySortedFunc(origTargets, uint64Cmp)
 
 	// Generate the positions needed to prove this.
 	proofPos, _ := proofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))

--- a/prove.go
+++ b/prove.go
@@ -782,12 +782,12 @@ func AddProof(proofA, proofB Proof, targetHashesA, targetHashesB []Hash, numLeav
 	totalRows := treeRows(numLeaves)
 
 	// Calculate proof hashes for proof A and add positions to the proof hashes.
-	targetsA := copySortedFunc(proofA.Targets, uint64Less)
+	targetsA := copySortedFunc(proofA.Targets, uint64Cmp)
 	proofPosA, calculateableA := proofPositions(targetsA, numLeaves, totalRows)
 	proofAndPosA := hashAndPos{proofPosA, proofA.Proof}
 
 	// Calculate proof hashes for proof B and add positions to the proof hashes.
-	targetsB := copySortedFunc(proofB.Targets, uint64Less)
+	targetsB := copySortedFunc(proofB.Targets, uint64Cmp)
 	proofPosB, calculateableB := proofPositions(targetsB, numLeaves, totalRows)
 	proofAndPosB := hashAndPos{proofPosB, proofB.Proof}
 
@@ -890,12 +890,12 @@ func (p *Proof) updateProofRemove(blockTargets []uint64, cachedHashes []Hash, up
 	totalRows := treeRows(numLeaves)
 
 	// Delete from the target.
-	sortedBlockTargets := copySortedFunc(blockTargets, uint64Less)
+	sortedBlockTargets := copySortedFunc(blockTargets, uint64Cmp)
 	targetsWithHash := toHashAndPos(p.Targets, cachedHashes)
 	targetsWithHash = subtractSortedHashAndPos(targetsWithHash, sortedBlockTargets, uint64Cmp)
 
 	// Attach positions to the proofs.
-	sortedCachedTargets := copySortedFunc(p.Targets, uint64Less)
+	sortedCachedTargets := copySortedFunc(p.Targets, uint64Cmp)
 	proofPos, _ := proofPositions(sortedCachedTargets, numLeaves, totalRows)
 	oldProofs := toHashAndPos(proofPos, p.Proof)
 	newProofs := hashAndPos{make([]uint64, 0, len(p.Proof)), make([]Hash, 0, len(p.Proof))}
@@ -905,7 +905,7 @@ func (p *Proof) updateProofRemove(blockTargets []uint64, cachedHashes []Hash, up
 
 	// Grab the un-needed positions. These are un-needed as they were proofs
 	// for the now deleted targets.
-	extraPos := copySortedFunc(oldProofs.positions, uint64Less)
+	extraPos := copySortedFunc(oldProofs.positions, uint64Cmp)
 	extraPos = subtractSortedSlice(extraPos, neededPos, uint64Cmp)
 
 	// Loop through oldProofs and only add the needed proof hashes.
@@ -933,7 +933,7 @@ func (p *Proof) updateProofRemove(blockTargets []uint64, cachedHashes []Hash, up
 	// Missing positions are the newly needed positions that aren't present in the proof.
 	// These positions are there because they were calculateable before the deletion in the
 	// previous proof.
-	missingPos := copySortedFunc(neededPos, uint64Less)
+	missingPos := copySortedFunc(neededPos, uint64Cmp)
 	missingPos = subtractSortedSlice(missingPos, oldProofs.positions, uint64Cmp)
 	missingPos = subtractSortedSlice(missingPos, sortedBlockTargets, uint64Cmp)
 
@@ -1263,10 +1263,10 @@ func (p *Proof) undoDel(blockTargets []uint64, blockHashes, cachedHashes []Hash,
 // NOTE The returned hashes and proof targets are in the same permutation as the given wants.
 func GetProofSubset(proof Proof, hashes []Hash, wants []uint64, numLeaves uint64) ([]Hash, Proof, error) {
 	// Copy to avoid mutating the original.
-	proofTargetsCopy := copySortedFunc(proof.Targets, uint64Less)
+	proofTargetsCopy := copySortedFunc(proof.Targets, uint64Cmp)
 
 	// Check that all the targets in removes are also present in the proof.
-	expectedEmpty := copySortedFunc(wants, uint64Less)
+	expectedEmpty := copySortedFunc(wants, uint64Cmp)
 	expectedEmpty = subtractSortedSlice(expectedEmpty, proofTargetsCopy, uint64Cmp)
 	if len(expectedEmpty) > 0 {
 		err := fmt.Errorf("Missing positions %v from the proof. Deletions %v, proof.Targets %v",
@@ -1294,7 +1294,7 @@ func GetProofSubset(proof Proof, hashes []Hash, wants []uint64, numLeaves uint64
 	posAndHashes = mergeSortedHashAndPos(posAndHashes, proofPos)
 
 	// Copy to avoid mutating the wants.
-	sortedWants := copySortedFunc(wants, uint64Less)
+	sortedWants := copySortedFunc(wants, uint64Cmp)
 	targetHashesWithPos = getHashAndPosSubset(targetHashesWithPos, sortedWants)
 
 	// Grab the positions that we need to prove the wants.

--- a/prove_test.go
+++ b/prove_test.go
@@ -295,12 +295,12 @@ func FuzzAddProof(f *testing.F) {
 		leafHashesC, proofC := AddProof(proofA, proofB, leafSubsetA.hashes, leafSubsetB.hashes, p.NumLeaves)
 
 		// These are the targets that we want to prove.
-		sortedProofATargets := copySortedFunc(proofA.Targets, uint64Less)
-		sortedProofBTargets := copySortedFunc(proofB.Targets, uint64Less)
+		sortedProofATargets := copySortedFunc(proofA.Targets, uint64Cmp)
+		sortedProofBTargets := copySortedFunc(proofB.Targets, uint64Cmp)
 		expectedTargets := mergeSortedSlicesFunc(sortedProofATargets, sortedProofBTargets, uint64Cmp)
 
 		// This is the targets that we got from AddProof.
-		sortedProofCTargets := copySortedFunc(proofC.Targets, uint64Less)
+		sortedProofCTargets := copySortedFunc(proofC.Targets, uint64Cmp)
 
 		// When we subtract the slice, we should get nothing since sortedProofCTargets and expectedTargets should
 		// be the same.
@@ -849,7 +849,7 @@ func FuzzGetProofSubset(f *testing.F) {
 		}
 
 		// Check that all the proves we want are there.
-		expectedEmpty := copySortedFunc(provePositions, uint64Less)
+		expectedEmpty := copySortedFunc(provePositions, uint64Cmp)
 		expectedEmpty = subtractSortedSlice(expectedEmpty, subsetProof.Targets, uint64Cmp)
 		if len(expectedEmpty) > 0 {
 			t.Fatalf("Positions %v did not get proven. All wanted positions: %v",

--- a/utils.go
+++ b/utils.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"slices"
 	"sort"
-
-	"golang.org/x/exp/slices"
 )
 
 // parentHash returns the hash of the left and right hashes passed in.
@@ -945,7 +944,7 @@ func uint64Less(a, b uint64) bool {
 }
 
 // copySortedFunc returns a copy of the slice passed in that's sorted.
-func copySortedFunc[E any](slice []E, less func(a, b E) bool) []E {
+func copySortedFunc[E any](slice []E, less func(a, b E) int) []E {
 	sliceCopy := make([]E, len(slice))
 	copy(sliceCopy, slice)
 


### PR DESCRIPTION
In an attempt to use `utreexod` as a chain backend in `lnd`, this error popped up,
```
.../utreexo/utils.go:952:29: type func(a E, b E) bool of less does not match inferred type func(a E, b E) int for func(a E, b E) int
```

Found the cause here:

> It turns out that a commit landed in [golang.org/x/exp](https://github.com/golang/exp/tree/master/slices) which changes the signature of the sorting functions, and breaks backward compatibility

More info can be found in this [answer](https://stackoverflow.com/questions/77275713/t-less-does-not-match-inferred-type-funca-t-b-t-int-for-funca-e-b-e-int).

The fix is simple, that we use `slices` from the standard lib instead.
