### PR TITLE
utils: simplify and export proofpositions

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -760,7 +760,7 @@ func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 	// Calculate the positions of the proofs and translate them if needed and
 	// then place in the proof hashes into the calculated positions.
 	sortedTargets := copySortedFunc(proof.Targets, uint64Less)
-	proofPos, _ := proofPositions(sortedTargets, m.NumLeaves, treeRows(m.NumLeaves))
+	proofPos, _ := ProofPositions(sortedTargets, m.NumLeaves, treeRows(m.NumLeaves))
 	if treeRows(m.NumLeaves) != m.TotalRows {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
 		proofPos = translatePositions(proofPos, treeRows(m.NumLeaves), m.TotalRows)
@@ -952,7 +952,7 @@ func (m *MapPollard) Prove(proveHashes []Hash) (Proof, error) {
 	targets := copySortedFunc(origTargets, uint64Less)
 
 	// The positions of the hashes we need to prove the passed in targets.
-	proofPos, _ := proofPositions(targets, m.NumLeaves, m.TotalRows)
+	proofPos, _ := ProofPositions(targets, m.NumLeaves, m.TotalRows)
 
 	// Go through all the needed positions and grab the hashes for them.
 	// If the node doesn't exist, check that it's calculateable. If it is,
@@ -997,7 +997,7 @@ func (m *MapPollard) VerifyPartialProof(origTargets []uint64, delHashes, proofHa
 	targets := copySortedFunc(origTargets, uint64Less)
 
 	// Figure out what hashes at which positions are needed.
-	proofPositions, _ := proofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
+	proofPositions, _ := ProofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
 
 	// Translate the proof positions if needed.
 	if treeRows(m.NumLeaves) != m.TotalRows {
@@ -1043,7 +1043,7 @@ func (m *MapPollard) GetMissingPositions(origTargets []uint64) []uint64 {
 	targets := copySortedFunc(origTargets, uint64Less)
 
 	// Generate the positions needed to prove this.
-	proofPos, _ := proofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
+	proofPos, _ := ProofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
 	if treeRows(m.NumLeaves) != m.TotalRows {
 		proofPos = translatePositions(proofPos, treeRows(m.NumLeaves), m.TotalRows)
 	}
@@ -1139,7 +1139,7 @@ func (m *MapPollard) ingest(delHashes []Hash, proof Proof) error {
 	}
 
 	// Calculate and ingest the proof.
-	proofPos, _ := proofPositions(hnp.positions, m.NumLeaves, m.TotalRows)
+	proofPos, _ := ProofPositions(hnp.positions, m.NumLeaves, m.TotalRows)
 	if treeRows(m.NumLeaves) != m.TotalRows && len(proofPos) != len(proof.Proof) {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
 	}

--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -78,7 +78,7 @@ func (m *MapPollard) checkPruned() error {
 	m.CachedLeaves.ForEach(func(_ Hash, v uint64) error {
 		neededPos[v] = struct{}{}
 
-		needs, computables := proofPositions([]uint64{v}, m.NumLeaves, m.TotalRows)
+		needs, computables := ProofPositions([]uint64{v}, m.NumLeaves, m.TotalRows)
 		for _, need := range needs {
 			neededPos[need] = struct{}{}
 		}
@@ -503,8 +503,8 @@ func FuzzMapPollardPrune(f *testing.F) {
 		slices.Sort(prunedPositions)
 
 		// Calculate the nodes that should not exist after the prune.
-		shouldNotExist, _ := proofPositions(prunedPositions, acc.NumLeaves, acc.TotalRows)
-		exist, _ := proofPositions(targets, acc.NumLeaves, acc.TotalRows)
+		shouldNotExist, _ := ProofPositions(prunedPositions, acc.NumLeaves, acc.TotalRows)
+		exist, _ := ProofPositions(targets, acc.NumLeaves, acc.TotalRows)
 		shouldNotExist = subtractSortedSlice(shouldNotExist, exist, uint64Cmp)
 
 		// Prune the randomly chosen hashes from the accumulator.
@@ -674,7 +674,7 @@ func TestGetMissingPositions(t *testing.T) {
 		}
 
 		// Calculate the positions actually needed.
-		needs, _ := proofPositions(proves, p.NumLeaves, treeRows(p.NumLeaves))
+		needs, _ := ProofPositions(proves, p.NumLeaves, treeRows(p.NumLeaves))
 		if treeRows(p.NumLeaves) != p.TotalRows {
 			needs = translatePositions(needs, treeRows(p.NumLeaves), p.TotalRows)
 		}

--- a/prove.go
+++ b/prove.go
@@ -80,7 +80,7 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 	sort.Slice(sortedTargets, func(a, b int) bool { return sortedTargets[a] < sortedTargets[b] })
 
 	// Get the positions of all the hashes that are needed to prove the targets
-	proofPositions, _ := proofPositions(sortedTargets, p.NumLeaves, treeRows(p.NumLeaves))
+	proofPositions, _ := ProofPositions(sortedTargets, p.NumLeaves, treeRows(p.NumLeaves))
 
 	// Fetch all the proofs from the accumulator.
 	proof.Proof = make([]Hash, len(proofPositions))
@@ -760,12 +760,12 @@ func GetMissingPositions(numLeaves uint64, proofTargets, desiredTargets []uint64
 	}
 
 	// desiredPositions are all the positions that are needed to proof the desiredTargets.
-	desiredPositions, _ := proofPositions(desiredTargets, numLeaves, forestRows)
+	desiredPositions, _ := ProofPositions(desiredTargets, numLeaves, forestRows)
 
 	// havePositions represent all the positions in the tree we already have access to.
 	// Since targets and computablePositions are something we already have, append
 	// those to the havePositions.
-	havePositions, computablePos := proofPositions(targets, numLeaves, forestRows)
+	havePositions, computablePos := ProofPositions(targets, numLeaves, forestRows)
 	havePositions = append(havePositions, targets...)
 	havePositions = append(havePositions, computablePos...)
 	sort.Slice(havePositions, func(a, b int) bool { return havePositions[a] < havePositions[b] })
@@ -783,12 +783,12 @@ func AddProof(proofA, proofB Proof, targetHashesA, targetHashesB []Hash, numLeav
 
 	// Calculate proof hashes for proof A and add positions to the proof hashes.
 	targetsA := copySortedFunc(proofA.Targets, uint64Less)
-	proofPosA, calculateableA := proofPositions(targetsA, numLeaves, totalRows)
+	proofPosA, calculateableA := ProofPositions(targetsA, numLeaves, totalRows)
 	proofAndPosA := hashAndPos{proofPosA, proofA.Proof}
 
 	// Calculate proof hashes for proof B and add positions to the proof hashes.
 	targetsB := copySortedFunc(proofB.Targets, uint64Less)
-	proofPosB, calculateableB := proofPositions(targetsB, numLeaves, totalRows)
+	proofPosB, calculateableB := ProofPositions(targetsB, numLeaves, totalRows)
 	proofAndPosB := hashAndPos{proofPosB, proofB.Proof}
 
 	// Add the proof hashes of proofA and proofB.
@@ -896,12 +896,12 @@ func (p *Proof) updateProofRemove(blockTargets []uint64, cachedHashes []Hash, up
 
 	// Attach positions to the proofs.
 	sortedCachedTargets := copySortedFunc(p.Targets, uint64Less)
-	proofPos, _ := proofPositions(sortedCachedTargets, numLeaves, totalRows)
+	proofPos, _ := ProofPositions(sortedCachedTargets, numLeaves, totalRows)
 	oldProofs := toHashAndPos(proofPos, p.Proof)
 	newProofs := hashAndPos{make([]uint64, 0, len(p.Proof)), make([]Hash, 0, len(p.Proof))}
 
 	// Grab all the positions of the needed proof hashes.
-	neededPos, _ := proofPositions(targetsWithHash.positions, numLeaves, totalRows)
+	neededPos, _ := ProofPositions(targetsWithHash.positions, numLeaves, totalRows)
 
 	// Grab the un-needed positions. These are un-needed as they were proofs
 	// for the now deleted targets.
@@ -1026,7 +1026,7 @@ func pruneEdges(hnp hashAndPos, numAdds, numLeaves uint64, forestRows, prevFores
 // proof hashes that could not have existed before the add.
 func (p *Proof) undoAdd(numAdds, numLeaves uint64, cachedHashes []Hash, toDestroy []uint64) ([]Hash, error) {
 	targetsWithHash := toHashAndPos(p.Targets, cachedHashes)
-	proofPos, _ := proofPositions(targetsWithHash.positions, numLeaves, treeRows(numLeaves))
+	proofPos, _ := ProofPositions(targetsWithHash.positions, numLeaves, treeRows(numLeaves))
 	proofWithPos := toHashAndPos(proofPos, p.Proof)
 
 	forestRows := treeRows(numLeaves)
@@ -1129,7 +1129,7 @@ func (p *Proof) undoAdd(numAdds, numLeaves uint64, cachedHashes []Hash, toDestro
 
 	// There may be extra proof hashes that we don't need anymore. Calculate the
 	// needed positions and remove the rest.
-	neededProofPos, _ := proofPositions(targetsWithHash.positions, numLeaves-numAdds, prevForestRows)
+	neededProofPos, _ := ProofPositions(targetsWithHash.positions, numLeaves-numAdds, prevForestRows)
 	proofWithPos = getHashAndPosSubset(proofWithPos, neededProofPos)
 
 	// Set the proof.
@@ -1150,7 +1150,7 @@ func (p *Proof) undoDel(blockTargets []uint64, blockHashes, cachedHashes []Hash,
 	}
 
 	targetsWithHashes := toHashAndPos(p.Targets, cachedHashes)
-	proofPos, _ := proofPositions(targetsWithHashes.positions, numLeaves, totalRows)
+	proofPos, _ := ProofPositions(targetsWithHashes.positions, numLeaves, totalRows)
 	proofWithPos := toHashAndPos(proofPos, p.Proof)
 
 	// Detwin the block targets.
@@ -1247,7 +1247,7 @@ func (p *Proof) undoDel(blockTargets []uint64, blockHashes, cachedHashes []Hash,
 
 	// Only extract the proof hashes that are needed for the targets after
 	// the remap.
-	neededProofPos, _ := proofPositions(targetsWithHashes.positions, numLeaves, totalRows)
+	neededProofPos, _ := ProofPositions(targetsWithHashes.positions, numLeaves, totalRows)
 	proofWithPos = getHashAndPosSubset(proofWithPos, neededProofPos)
 
 	p.Proof = proofWithPos.hashes
@@ -1286,7 +1286,7 @@ func GetProofSubset(proof Proof, hashes []Hash, wants []uint64, numLeaves uint64
 	sort.Sort(posAndHashes)
 
 	// Put positions onto the proof hashes.
-	positions, _ := proofPositions(proofTargetsCopy, numLeaves, treeRows(numLeaves))
+	positions, _ := ProofPositions(proofTargetsCopy, numLeaves, treeRows(numLeaves))
 	proofPos := toHashAndPos(positions, proof.Proof)
 
 	// Merge the proof positions and its hashes along with the calculated intermediate nodes
@@ -1298,7 +1298,7 @@ func GetProofSubset(proof Proof, hashes []Hash, wants []uint64, numLeaves uint64
 	targetHashesWithPos = getHashAndPosSubset(targetHashesWithPos, sortedWants)
 
 	// Grab the positions that we need to prove the wants.
-	wantProofPos, _ := proofPositions(targetHashesWithPos.positions, numLeaves, treeRows(numLeaves))
+	wantProofPos, _ := ProofPositions(targetHashesWithPos.positions, numLeaves, treeRows(numLeaves))
 
 	// Extract the proof positions we want and then sanity check to see that we have everything.
 	posAndHashes = getHashAndPosSubset(posAndHashes, wantProofPos)
@@ -1350,7 +1350,7 @@ func (p *Proof) updateProofAdd(adds, cachedDelHashes []Hash, remembers []uint32,
 	origTargetsWithHash := toHashAndPos(p.Targets, cachedDelHashes)
 
 	// Attach positions to the proof.
-	proofPos, _ := proofPositions(origTargetsWithHash.positions, beforeNumLeaves, treeRows(beforeNumLeaves))
+	proofPos, _ := ProofPositions(origTargetsWithHash.positions, beforeNumLeaves, treeRows(beforeNumLeaves))
 	proofWithPos := toHashAndPos(proofPos, p.Proof)
 
 	// Remap the positions if we moved up a after the addition row.
@@ -1391,7 +1391,7 @@ func (p *Proof) updateProofAdd(adds, cachedDelHashes []Hash, remembers []uint32,
 	origTargetsWithHash = mergeSortedHashAndPos(remembersWithHash, origTargetsWithHash)
 
 	// Grab all the new nodes after this add.
-	neededProofPositions, _ := proofPositions(origTargetsWithHash.positions, beforeNumLeaves+uint64(len(adds)), treeRows(beforeNumLeaves+uint64(len(adds))))
+	neededProofPositions, _ := ProofPositions(origTargetsWithHash.positions, beforeNumLeaves+uint64(len(adds)), treeRows(beforeNumLeaves+uint64(len(adds))))
 
 	// Add all the new proof hashes to the proof.
 	newProofWithPos := hashAndPos{}

--- a/prove_test.go
+++ b/prove_test.go
@@ -68,14 +68,14 @@ func calcDelHashAndProof(p *Pollard, proof Proof, missingPositions, desiredPosit
 	}
 
 	// Attach positions to the proof hashes.
-	proofPos, _ := proofPositions(proof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
+	proofPos, _ := ProofPositions(proof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
 	currentHashes := toHashAndPos(proofPos, proof.Proof)
 	// Append the needed hashes to the proof.
 	currentHashes.AppendMany(neededHashes.positions, neededHashes.hashes)
 
 	// As new targets are added, we're able to calulate positions that we couldn't before. These positions
 	// may already exist as proofs. Remove these as duplicates are not expected during proof verification.
-	_, calculateables := proofPositions(desiredPositions, p.NumLeaves, treeRows(p.NumLeaves))
+	_, calculateables := ProofPositions(desiredPositions, p.NumLeaves, treeRows(p.NumLeaves))
 	for _, cal := range calculateables {
 		idx := slices.IndexFunc(currentHashes.positions, func(elem uint64) bool { return elem == cal })
 		if idx != -1 {
@@ -450,7 +450,7 @@ func FuzzUpdateProofRemove(f *testing.F) {
 				pollardBeforeStr, p.String())
 		}
 
-		cachedProofPos, _ := proofPositions(cachedProof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
+		cachedProofPos, _ := ProofPositions(cachedProof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
 		if len(cachedProofPos) != len(cachedProof.Proof) {
 			t.Fatalf("FuzzUpdateProofRemove Fail. CachedProof has these hashes:\n%v\n"+
 				"for these targets:\n%v\n"+

--- a/stump_test.go
+++ b/stump_test.go
@@ -234,7 +234,7 @@ func checkUpdateData(updateData UpdateData, adds, delHashes, prevRoots []Hash, p
 	 */
 	// Attach the hashes to their positions.
 	targetsWithHash := toHashAndPos(proof.Targets, delHashes)
-	proofPos, _ := proofPositions(targetsWithHash.positions, updateData.PrevNumLeaves, treeRows(updateData.PrevNumLeaves))
+	proofPos, _ := ProofPositions(targetsWithHash.positions, updateData.PrevNumLeaves, treeRows(updateData.PrevNumLeaves))
 	proofWithPositions := toHashAndPos(proofPos, proof.Proof)
 
 	// Update accordingly.

--- a/utils.go
+++ b/utils.go
@@ -553,9 +553,10 @@ func proofPosition(target uint64, numLeaves uint64, totalRows uint8) []uint64 {
 	return proofs
 }
 
-// proofPositions returns all the positions that are needed to prove targets passed in.
+// ProofPositions returns all the positions that are needed to prove targets passed in along with
+// all the positions that are able to be computed.
 // NOTE: the passed in targets MUST be sorted.
-func proofPositions(origTargets []uint64, numLeaves uint64, totalRows uint8) ([]uint64, []uint64) {
+func ProofPositions(origTargets []uint64, numLeaves uint64, totalRows uint8) ([]uint64, []uint64) {
 	targets := make([]uint64, len(origTargets))
 	copy(targets, origTargets)
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,7 +27,7 @@ func TestProofPosition(t *testing.T) {
 
 	for _, test := range tests {
 		got := proofPosition(test.position, test.numLeaves, test.totalRows)
-		expect, _ := proofPositions([]uint64{test.position}, test.numLeaves, test.totalRows)
+		expect, _ := ProofPositions([]uint64{test.position}, test.numLeaves, test.totalRows)
 
 		if !reflect.DeepEqual(got, expect) {
 			t.Fatalf("expected %v, got %v for numleaves %d, totalrows %d",


### PR DESCRIPTION
proofpositions is needed for the new block download protocol that
requires the client to compute for which proof positions it needs.
Exporting gives utreexod the ability to call it.

Simplifying is just cherry on top and prevent possible infinite loop bugs.