### PR TITLE
main, .github: update to go 0.21.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.18]
+        go: [1.21]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/utreexo/utreexo
 
-go 1.18
+go 1.21
 
 require golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -1439,7 +1439,7 @@ func compareNodeMap(mapA, mapB map[miniHash]*polNode) error {
 			keyStr, printPolNodes(mapBNodes), printPolNodes(mapANodes))
 	}
 
-	return fmt.Errorf(str)
+	return fmt.Errorf("%v", str)
 }
 
 func TestGetLeafPosition(t *testing.T) {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,7 +6,7 @@ env GORACE="halt_on_error=1" go test -race
 env GORACE="halt_on_error=1" go test -covermode atomic -coverprofile=profile.cov ./...
 
 # Automatic checks
-golangci-lint run --disable-all --deadline=10m \
+golangci-lint run --disable-all \
 --enable=gofmt \
 --enable=gosimple \
 --enable=unconvert \

--- a/utils.go
+++ b/utils.go
@@ -712,7 +712,7 @@ func AllSubTreesToString(ts ToString) string {
 	for h := uint8(0); h < totalRows; h++ {
 		rootPos := rootPosition(ts.GetNumLeaves(), h, totalRows)
 		if isRootPosition(rootPos, ts.GetNumLeaves()) {
-			str += fmt.Sprintf(SubTreeToString(ts, rootPos, false))
+			str += SubTreeToString(ts, rootPos, false)
 			str += "\n"
 		}
 	}


### PR DESCRIPTION
The usage of slices package as a standard library was introduced in go v0.21.0. Updating the package so we have access to the library.