### PR TITLE
prove: don't allocate proof slice if it's empty

### DIFF
--- a/prove.go
+++ b/prove.go
@@ -81,6 +81,10 @@ func (p *Pollard) Prove(hashes []Hash) (Proof, error) {
 
 	// Get the positions of all the hashes that are needed to prove the targets
 	proofPositions, _ := ProofPositions(sortedTargets, p.NumLeaves, treeRows(p.NumLeaves))
+	if len(proofPositions) == 0 {
+		// Return early.
+		return proof, nil
+	}
 
 	// Fetch all the proofs from the accumulator.
 	proof.Proof = make([]Hash, len(proofPositions))


### PR DESCRIPTION
For reflect.DeepEqual(), it won't equal if the proof slice is nil vs empty. Since by default it's nil, don't init unless if there's a need.