### PR TITLE
utreexo: export treeRows

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -455,7 +455,7 @@ func (m *MapPollard) moveUpChild(position, delPos, numLeaves uint64,
 // remap moves up the positions of nodes that aren't at row 0 whenever the accumulator grows.
 // Returns the total number of rows needed to house numleaves+1 amount of leaves.
 func (m *MapPollard) remap() (uint8, error) {
-	nextRows := treeRows(m.NumLeaves + 1)
+	nextRows := TreeRows(m.NumLeaves + 1)
 	if nextRows <= m.TotalRows {
 		return m.TotalRows, nil
 	}
@@ -626,8 +626,8 @@ func (m *MapPollard) remove(proof Proof, delHashes []Hash) error {
 	m.uncacheLeaves(delHashes)
 
 	detwinedDels := copySortedFunc(proof.Targets, uint64Cmp)
-	if m.TotalRows != treeRows(m.NumLeaves) {
-		detwinedDels = translatePositions(detwinedDels, treeRows(m.NumLeaves), m.TotalRows)
+	if m.TotalRows != TreeRows(m.NumLeaves) {
+		detwinedDels = translatePositions(detwinedDels, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 
 	detwinedDels = deTwin(detwinedDels, m.TotalRows)
@@ -718,8 +718,8 @@ func (m *MapPollard) placeEmptyRoot(prevRootPos uint64) error {
 func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 	// Sort and translate the positions if needed.
 	hnp := toHashAndPos(proof.Targets, hashes)
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		hnp.positions = translatePositions(hnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		hnp.positions = translatePositions(hnp.positions, TreeRows(m.NumLeaves), m.TotalRows)
 		sort.Sort(hnp)
 	}
 
@@ -760,10 +760,10 @@ func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 	// Calculate the positions of the proofs and translate them if needed and
 	// then place in the proof hashes into the calculated positions.
 	sortedTargets := copySortedFunc(proof.Targets, uint64Cmp)
-	proofPos, _ := ProofPositions(sortedTargets, m.NumLeaves, treeRows(m.NumLeaves))
-	if treeRows(m.NumLeaves) != m.TotalRows {
+	proofPos, _ := ProofPositions(sortedTargets, m.NumLeaves, TreeRows(m.NumLeaves))
+	if TreeRows(m.NumLeaves) != m.TotalRows {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
-		proofPos = translatePositions(proofPos, treeRows(m.NumLeaves), m.TotalRows)
+		proofPos = translatePositions(proofPos, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 
 	if len(proofPos) != len(proof.Proof) {
@@ -791,8 +791,8 @@ func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 	if err != nil {
 		return err
 	}
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		newhnp.positions = translatePositions(newhnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		newhnp.positions = translatePositions(newhnp.positions, TreeRows(m.NumLeaves), m.TotalRows)
 		sort.Sort(newhnp)
 	}
 
@@ -804,8 +804,8 @@ func (m *MapPollard) undoDeletion(proof Proof, hashes []Hash) error {
 			remember = true
 		}
 		for _, target := range proof.Targets {
-			if treeRows(m.NumLeaves) != m.TotalRows {
-				translated := translatePos(target, treeRows(m.NumLeaves), m.TotalRows)
+			if TreeRows(m.NumLeaves) != m.TotalRows {
+				translated := translatePos(target, TreeRows(m.NumLeaves), m.TotalRows)
 				if pos == translated {
 					remember = true
 				}
@@ -833,7 +833,7 @@ func (m *MapPollard) getRootsAfterDel(numAdds uint64, targets, prevRootPos []uin
 	copy(prevRoots, origPrevRoots)
 
 	detwined := deTwin(translatePositions(copySortedFunc(targets, uint64Cmp),
-		treeRows(m.NumLeaves-numAdds), m.TotalRows), m.TotalRows)
+		TreeRows(m.NumLeaves-numAdds), m.TotalRows), m.TotalRows)
 
 	for i := range detwined {
 		for j := range prevRootPos {
@@ -858,8 +858,8 @@ func (m *MapPollard) getWrittenOverEmptyRoots(numAdds uint64, origTargets []uint
 	destroyedPositions := rootsToDestory(numAdds, m.NumLeaves-numAdds, prevRoots)
 
 	// Translate the positions if needed.
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		destroyedPositions = translatePositions(destroyedPositions, treeRows(m.NumLeaves), m.TotalRows)
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		destroyedPositions = translatePositions(destroyedPositions, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 
 	// Loop through all the previous roots and only add their position to the previous
@@ -975,9 +975,9 @@ func (m *MapPollard) Prove(proveHashes []Hash) (Proof, error) {
 
 	// If the map pollard is set with higher rows than what's actually needed,
 	// translate the positions.
-	if m.TotalRows != treeRows(m.NumLeaves) {
+	if m.TotalRows != TreeRows(m.NumLeaves) {
 		for i := range origTargets {
-			origTargets[i] = translatePos(origTargets[i], m.TotalRows, treeRows(m.NumLeaves))
+			origTargets[i] = translatePos(origTargets[i], m.TotalRows, TreeRows(m.NumLeaves))
 		}
 	}
 
@@ -997,11 +997,11 @@ func (m *MapPollard) VerifyPartialProof(origTargets []uint64, delHashes, proofHa
 	targets := copySortedFunc(origTargets, uint64Cmp)
 
 	// Figure out what hashes at which positions are needed.
-	proofPositions, _ := ProofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
+	proofPositions, _ := ProofPositions(targets, m.NumLeaves, TreeRows(m.NumLeaves))
 
 	// Translate the proof positions if needed.
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		proofPositions = translatePositions(proofPositions, treeRows(m.NumLeaves), m.TotalRows)
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		proofPositions = translatePositions(proofPositions, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 
 	// Where we'll merge the hashes that we already have with the proofHashes provided.
@@ -1043,9 +1043,9 @@ func (m *MapPollard) GetMissingPositions(origTargets []uint64) []uint64 {
 	targets := copySortedFunc(origTargets, uint64Cmp)
 
 	// Generate the positions needed to prove this.
-	proofPos, _ := ProofPositions(targets, m.NumLeaves, treeRows(m.NumLeaves))
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		proofPos = translatePositions(proofPos, treeRows(m.NumLeaves), m.TotalRows)
+	proofPos, _ := ProofPositions(targets, m.NumLeaves, TreeRows(m.NumLeaves))
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		proofPos = translatePositions(proofPos, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 
 	// Go through all the proof positions and mark the ones that are missing.
@@ -1058,8 +1058,8 @@ func (m *MapPollard) GetMissingPositions(origTargets []uint64) []uint64 {
 		}
 	}
 
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		missingPositions = translatePositions(missingPositions, m.TotalRows, treeRows(m.NumLeaves))
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		missingPositions = translatePositions(missingPositions, m.TotalRows, TreeRows(m.NumLeaves))
 		missingPositions = m.trimProofPos(missingPositions, m.NumLeaves)
 	}
 
@@ -1080,8 +1080,8 @@ func (m *MapPollard) Verify(delHashes []Hash, proof Proof, remember bool) error 
 //
 // This function is different from Verify() in that it's not safe for concurrent access.
 func (m *MapPollard) verify(delHashes []Hash, proof Proof, remember bool) error {
-	if treeRows(m.NumLeaves) != m.TotalRows {
-		proof.Targets = translatePositions(proof.Targets, m.TotalRows, treeRows(m.NumLeaves))
+	if TreeRows(m.NumLeaves) != m.TotalRows {
+		proof.Targets = translatePositions(proof.Targets, m.TotalRows, TreeRows(m.NumLeaves))
 	}
 
 	s := m.getStump()
@@ -1102,7 +1102,7 @@ func (m *MapPollard) verify(delHashes []Hash, proof Proof, remember bool) error 
 //
 // The given proof positions must be sorted.
 func (m *MapPollard) trimProofPos(proofPos []uint64, numLeaves uint64) []uint64 {
-	rows := treeRows(numLeaves)
+	rows := TreeRows(numLeaves)
 
 	i := 0
 	for ; i < len(proofPos); i++ {
@@ -1133,14 +1133,14 @@ func (m *MapPollard) Ingest(delHashes []Hash, proof Proof) error {
 // This function is different from Ingest() in that it's not safe for concurrent access.
 func (m *MapPollard) ingest(delHashes []Hash, proof Proof) error {
 	hnp := toHashAndPos(proof.Targets, delHashes)
-	if m.TotalRows != treeRows(m.NumLeaves) {
-		hnp.positions = translatePositions(hnp.positions, treeRows(m.NumLeaves), m.TotalRows)
+	if m.TotalRows != TreeRows(m.NumLeaves) {
+		hnp.positions = translatePositions(hnp.positions, TreeRows(m.NumLeaves), m.TotalRows)
 		sort.Sort(hnp)
 	}
 
 	// Calculate and ingest the proof.
 	proofPos, _ := ProofPositions(hnp.positions, m.NumLeaves, m.TotalRows)
-	if treeRows(m.NumLeaves) != m.TotalRows && len(proofPos) != len(proof.Proof) {
+	if TreeRows(m.NumLeaves) != m.TotalRows && len(proofPos) != len(proof.Proof) {
 		proofPos = m.trimProofPos(proofPos, m.NumLeaves)
 	}
 	for i, pos := range proofPos {
@@ -1157,8 +1157,8 @@ func (m *MapPollard) ingest(delHashes []Hash, proof Proof) error {
 	if err != nil {
 		return err
 	}
-	if m.TotalRows != treeRows(m.NumLeaves) {
-		intermediate.positions = translatePositions(intermediate.positions, treeRows(m.NumLeaves), m.TotalRows)
+	if m.TotalRows != TreeRows(m.NumLeaves) {
+		intermediate.positions = translatePositions(intermediate.positions, TreeRows(m.NumLeaves), m.TotalRows)
 		sort.Sort(intermediate)
 	}
 
@@ -1212,7 +1212,7 @@ func (m *MapPollard) Prune(hashes []Hash) error {
 		m.Nodes.Put(pos, leaf)
 
 		// Call prune positions until the root.
-		for row := detectRow(pos, m.TotalRows); row <= treeRows(m.NumLeaves); row++ {
+		for row := detectRow(pos, m.TotalRows); row <= TreeRows(m.NumLeaves); row++ {
 			// Break if we're on a root.
 			if isRootPositionTotalRows(pos, m.NumLeaves, m.TotalRows) {
 				break
@@ -1256,8 +1256,8 @@ func (m *MapPollard) GetHash(pos uint64) Hash {
 	m.rwLock.RLock()
 	defer m.rwLock.RUnlock()
 
-	if m.TotalRows != treeRows(m.NumLeaves) {
-		pos = translatePos(pos, treeRows(m.NumLeaves), m.TotalRows)
+	if m.TotalRows != TreeRows(m.NumLeaves) {
+		pos = translatePos(pos, TreeRows(m.NumLeaves), m.TotalRows)
 	}
 	leaf, _ := m.Nodes.Get(pos)
 	return leaf.Hash
@@ -1273,8 +1273,8 @@ func (m *MapPollard) getLeafHashPosition(hash Hash) (uint64, bool) {
 		return 0, false
 	}
 
-	if m.TotalRows != treeRows(m.NumLeaves) {
-		pos = translatePos(pos, m.TotalRows, treeRows(m.NumLeaves))
+	if m.TotalRows != TreeRows(m.NumLeaves) {
+		pos = translatePos(pos, m.TotalRows, TreeRows(m.NumLeaves))
 	}
 
 	return pos, true
@@ -1290,7 +1290,7 @@ func (m *MapPollard) GetLeafPosition(hash Hash) (uint64, bool) {
 }
 
 func (m *MapPollard) highestPos() uint64 {
-	totalRows := treeRows(m.NumLeaves)
+	totalRows := TreeRows(m.NumLeaves)
 	pos := rootPosition(m.NumLeaves, totalRows, totalRows)
 	return translatePos(pos, totalRows, m.TotalRows)
 }

--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -151,9 +151,9 @@ func (m *MapPollard) checkHashes() error {
 		return err
 	}
 
-	if m.TotalRows != treeRows(m.NumLeaves) {
+	if m.TotalRows != TreeRows(m.NumLeaves) {
 		for i := range proof.Targets {
-			proof.Targets[i] = translatePos(proof.Targets[i], m.TotalRows, treeRows(m.NumLeaves))
+			proof.Targets[i] = translatePos(proof.Targets[i], m.TotalRows, TreeRows(m.NumLeaves))
 		}
 	}
 
@@ -284,8 +284,8 @@ func FuzzMapPollardChain(f *testing.F) {
 
 			for _, target := range proof.Targets {
 				fetch := target
-				if m.TotalRows != treeRows(m.NumLeaves) {
-					fetch = translatePos(fetch, treeRows(m.NumLeaves), m.TotalRows)
+				if m.TotalRows != TreeRows(m.NumLeaves) {
+					fetch = translatePos(fetch, TreeRows(m.NumLeaves), m.TotalRows)
 				}
 				hash := m.GetHash(fetch)
 				if hash == empty {
@@ -330,10 +330,10 @@ func FuzzMapPollardChain(f *testing.F) {
 				t.Fatal(err)
 			}
 
-			if m.TotalRows != treeRows(m.NumLeaves) {
+			if m.TotalRows != TreeRows(m.NumLeaves) {
 				for i := range cachedProof.Targets {
 					cachedProof.Targets[i] = translatePos(
-						cachedProof.Targets[i], m.TotalRows, treeRows(m.NumLeaves))
+						cachedProof.Targets[i], m.TotalRows, TreeRows(m.NumLeaves))
 				}
 			}
 
@@ -650,15 +650,15 @@ func TestGetMissingPositions(t *testing.T) {
 	sanityCheck := func(t *testing.T, p *MapPollard, proves, missing []uint64) {
 		// Check that all the positions can actually exist.
 		for i := range missing {
-			if !inForest(missing[i], p.NumLeaves, treeRows(p.NumLeaves)) {
+			if !inForest(missing[i], p.NumLeaves, TreeRows(p.NumLeaves)) {
 				t.Fatalf("pos %d cannot exist in an accumulator with %d leaves",
 					missing[i], p.NumLeaves)
 			}
 		}
 
 		// Translate if needed.
-		if treeRows(p.NumLeaves) != p.TotalRows {
-			missing = translatePositions(missing, treeRows(p.NumLeaves), p.TotalRows)
+		if TreeRows(p.NumLeaves) != p.TotalRows {
+			missing = translatePositions(missing, TreeRows(p.NumLeaves), p.TotalRows)
 		}
 
 		// Check for duplicates and turn the slice into a map for easy lookup.
@@ -674,9 +674,9 @@ func TestGetMissingPositions(t *testing.T) {
 		}
 
 		// Calculate the positions actually needed.
-		needs, _ := ProofPositions(proves, p.NumLeaves, treeRows(p.NumLeaves))
-		if treeRows(p.NumLeaves) != p.TotalRows {
-			needs = translatePositions(needs, treeRows(p.NumLeaves), p.TotalRows)
+		needs, _ := ProofPositions(proves, p.NumLeaves, TreeRows(p.NumLeaves))
+		if TreeRows(p.NumLeaves) != p.TotalRows {
+			needs = translatePositions(needs, TreeRows(p.NumLeaves), p.TotalRows)
 		}
 
 		// Check that the missing positions are indeed missing.
@@ -935,7 +935,7 @@ func TestGetLeafHashPositions(t *testing.T) {
 	}
 
 	// Actual test is here.
-	expected := parent(0, treeRows(uint64(len(leaves))))
+	expected := parent(0, TreeRows(uint64(len(leaves))))
 	got, found := acc.getLeafHashPosition(leaves[0].Hash)
 	if !found {
 		t.Fatalf("expected to find position for hash %v but didn't", leaves[0].Hash)

--- a/pollard.go
+++ b/pollard.go
@@ -64,7 +64,7 @@ func (p *Pollard) GetNumLeaves() uint64 {
 
 // GetTreeRows returns the total number of rows the accumulator has allocated for.
 func (p *Pollard) GetTreeRows() uint8 {
-	return treeRows(p.NumLeaves)
+	return TreeRows(p.NumLeaves)
 }
 
 // GetLeafPosition returns the position of the leaf for the given hash. Returns false if
@@ -192,7 +192,7 @@ func (p *Pollard) calculateNewRoot(node *polNode) *polNode {
 func (p *Pollard) remove(dels []uint64) error {
 	sort.Slice(dels, func(a, b int) bool { return dels[a] < dels[b] })
 
-	totalRows := treeRows(p.NumLeaves)
+	totalRows := TreeRows(p.NumLeaves)
 	dels = deTwin(dels, totalRows)
 
 	for _, del := range dels {
@@ -293,7 +293,7 @@ func (p *Pollard) deleteSingle(del uint64) error {
 
 	// If to position is a root, there's no parent hash to be calculated so
 	// return early.
-	totalRows := treeRows(p.NumLeaves)
+	totalRows := TreeRows(p.NumLeaves)
 	to := parent(del, totalRows)
 	if isRootPosition(to, p.NumLeaves) {
 		toNode.aunt = nil
@@ -365,7 +365,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 
 	// Sort before detwining.
 	sort.Slice(dels, func(a, b int) bool { return dels[a] < dels[b] })
-	dels = deTwin(dels, treeRows(p.NumLeaves))
+	dels = deTwin(dels, TreeRows(p.NumLeaves))
 
 	// Copy to avoid mutating the original.
 	copyRoots := make([]Hash, len(prevRoots))
@@ -402,7 +402,7 @@ func (p *Pollard) undoEmptyRoots(numAdds uint64, origDels []uint64, prevRoots []
 
 // undoSingleAdd undoes one leaf that was added to the accumulator.
 func (p *Pollard) undoSingleAdd() {
-	lowestRootRow := getLowestRoot(p.NumLeaves, treeRows(p.NumLeaves))
+	lowestRootRow := getLowestRoot(p.NumLeaves, TreeRows(p.NumLeaves))
 	for row := int(lowestRootRow); row >= 0; row-- {
 		lowestRoot := p.Roots[len(p.Roots)-1]
 		p.Roots = p.Roots[:len(p.Roots)-1]
@@ -438,7 +438,7 @@ func (p *Pollard) undoDels(dels []uint64, delHashes []Hash) error {
 	}
 	sort.Slice(pnps, func(a, b int) bool { return pnps[a].pos < pnps[b].pos })
 
-	totalRows := treeRows(p.NumLeaves)
+	totalRows := TreeRows(p.NumLeaves)
 	pnps = deTwinPolNode(pnps, totalRows)
 
 	// Go through all the de-twined nodes and all from the highest position first.
@@ -466,7 +466,7 @@ func (p *Pollard) undoDels(dels []uint64, delHashes []Hash) error {
 }
 
 func (p *Pollard) undoSingleDel(node *polNode, pos uint64) error {
-	totalRows := treeRows(p.NumLeaves)
+	totalRows := TreeRows(p.NumLeaves)
 
 	siblingPos := parent(pos, totalRows)
 	sibling, aunt, _, err := p.getNode(siblingPos)

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -356,7 +356,7 @@ func (p *Pollard) checkHashes() error {
 // calculates its position. Returns an error if the position calculated does
 // not match the position used to fetch the node.
 func (p *Pollard) positionSanity() error {
-	totalRows := treeRows(p.NumLeaves)
+	totalRows := TreeRows(p.NumLeaves)
 
 	for row := uint8(0); row < totalRows; row++ {
 		pos := startPositionAtRow(row, totalRows)
@@ -1108,8 +1108,8 @@ func fuzzUndoChain(t *testing.T, p UtreexoTest, blockCount, numAdds, duration ui
 
 		for i := range bp.Targets {
 			var gotHash Hash
-			if treeRows(p.GetNumLeaves()) != p.GetTreeRows() {
-				gotHash = p.GetHash(translatePos(bp.Targets[i], treeRows(p.GetNumLeaves()), p.GetTreeRows()))
+			if TreeRows(p.GetNumLeaves()) != p.GetTreeRows() {
+				gotHash = p.GetHash(translatePos(bp.Targets[i], TreeRows(p.GetNumLeaves()), p.GetTreeRows()))
 			} else {
 				gotHash = p.GetHash(bp.Targets[i])
 			}

--- a/polnode.go
+++ b/polnode.go
@@ -126,7 +126,7 @@ func (p *Pollard) getNode(pos uint64) (n, sibling, parent *polNode, err error) {
 	// Tree is the root the position is located under.
 	// branchLen denotes how far down the root the position is.
 	// bits tell us if we should go down to the left child or the right child.
-	if pos >= maxPosition(treeRows(p.NumLeaves)) {
+	if pos >= maxPosition(TreeRows(p.NumLeaves)) {
 		return nil, nil, nil,
 			fmt.Errorf("Position %d does not exist in tree of %d leaves", pos, p.NumLeaves)
 	}
@@ -211,7 +211,7 @@ func (p *Pollard) calculatePosition(node *polNode) uint64 {
 		}
 		rowsToTop++
 	}
-	forestRows := treeRows(p.NumLeaves)
+	forestRows := TreeRows(p.NumLeaves)
 
 	// Calculate which row the root is on.
 	rootRow := -1

--- a/prove_test.go
+++ b/prove_test.go
@@ -68,14 +68,14 @@ func calcDelHashAndProof(p *Pollard, proof Proof, missingPositions, desiredPosit
 	}
 
 	// Attach positions to the proof hashes.
-	proofPos, _ := ProofPositions(proof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
+	proofPos, _ := ProofPositions(proof.Targets, p.NumLeaves, TreeRows(p.NumLeaves))
 	currentHashes := toHashAndPos(proofPos, proof.Proof)
 	// Append the needed hashes to the proof.
 	currentHashes.AppendMany(neededHashes.positions, neededHashes.hashes)
 
 	// As new targets are added, we're able to calulate positions that we couldn't before. These positions
 	// may already exist as proofs. Remove these as duplicates are not expected during proof verification.
-	_, calculateables := ProofPositions(desiredPositions, p.NumLeaves, treeRows(p.NumLeaves))
+	_, calculateables := ProofPositions(desiredPositions, p.NumLeaves, TreeRows(p.NumLeaves))
 	for _, cal := range calculateables {
 		idx := slices.IndexFunc(currentHashes.positions, func(elem uint64) bool { return elem == cal })
 		if idx != -1 {
@@ -450,7 +450,7 @@ func FuzzUpdateProofRemove(f *testing.F) {
 				pollardBeforeStr, p.String())
 		}
 
-		cachedProofPos, _ := ProofPositions(cachedProof.Targets, p.NumLeaves, treeRows(p.NumLeaves))
+		cachedProofPos, _ := ProofPositions(cachedProof.Targets, p.NumLeaves, TreeRows(p.NumLeaves))
 		if len(cachedProofPos) != len(cachedProof.Proof) {
 			t.Fatalf("FuzzUpdateProofRemove Fail. CachedProof has these hashes:\n%v\n"+
 				"for these targets:\n%v\n"+

--- a/stump.go
+++ b/stump.go
@@ -135,7 +135,7 @@ func (s *Stump) del(delHashes []Hash, proof Proof) ([]Hash, []uint64, error) {
 // positions used to calculate the newly created roots.
 func (s *Stump) add(adds []Hash) ([]Hash, []uint64, []uint64) {
 	// afterRows is the total amount of rows after the addition has happened.
-	afterRows := treeRows(s.NumLeaves + uint64(len(adds)))
+	afterRows := TreeRows(s.NumLeaves + uint64(len(adds)))
 
 	// allDeleted is all the empty roots that get deleted by the additions.
 	allDeleted := rootsToDestory(uint64(len(adds)), s.NumLeaves, s.Roots)
@@ -232,13 +232,13 @@ func rootsToDestory(numAdds, numLeaves uint64, origRoots []Hash) []uint64 {
 	roots := make([]Hash, len(origRoots))
 	copy(roots, origRoots)
 
-	deleted := make([]uint64, 0, treeRows(numLeaves+numAdds))
+	deleted := make([]uint64, 0, TreeRows(numLeaves+numAdds))
 	for i := uint64(0); i < numAdds; i++ {
 		for h := uint8(0); (numLeaves>>h)&1 == 1; h++ {
 			root := roots[len(roots)-1]
 			roots = roots[:len(roots)-1]
 			if root == empty {
-				rootPos := rootPosition(numLeaves, h, treeRows(numLeaves+(numAdds-i)))
+				rootPos := rootPosition(numLeaves, h, TreeRows(numLeaves+(numAdds-i)))
 				deleted = append(deleted, rootPos)
 			}
 		}

--- a/stump_test.go
+++ b/stump_test.go
@@ -234,7 +234,7 @@ func checkUpdateData(updateData UpdateData, adds, delHashes, prevRoots []Hash, p
 	 */
 	// Attach the hashes to their positions.
 	targetsWithHash := toHashAndPos(proof.Targets, delHashes)
-	proofPos, _ := ProofPositions(targetsWithHash.positions, updateData.PrevNumLeaves, treeRows(updateData.PrevNumLeaves))
+	proofPos, _ := ProofPositions(targetsWithHash.positions, updateData.PrevNumLeaves, TreeRows(updateData.PrevNumLeaves))
 	proofWithPositions := toHashAndPos(proofPos, proof.Proof)
 
 	// Update accordingly.

--- a/utils.go
+++ b/utils.go
@@ -124,8 +124,8 @@ func RootPositions(numLeaves uint64, totalRows uint8) []uint64 {
 // isRootPositionTotalRows is a wrapper around isRootPosition that will translate the given
 // position if needed.
 func isRootPositionTotalRows(position, numLeaves uint64, totalRows uint8) bool {
-	if totalRows != treeRows(numLeaves) {
-		translated := translatePos(position, totalRows, treeRows(numLeaves))
+	if totalRows != TreeRows(numLeaves) {
+		translated := translatePos(position, totalRows, TreeRows(numLeaves))
 		return isRootPosition(translated, numLeaves)
 	}
 
@@ -135,7 +135,7 @@ func isRootPositionTotalRows(position, numLeaves uint64, totalRows uint8) bool {
 // isRootPosition checks if the current position is a root given the number of
 // leaves.
 func isRootPosition(position, numLeaves uint64) bool {
-	row := detectRow(position, treeRows(numLeaves))
+	row := detectRow(position, TreeRows(numLeaves))
 	return isRootPositionOnRow(position, numLeaves, row)
 }
 
@@ -143,7 +143,7 @@ func isRootPosition(position, numLeaves uint64) bool {
 // leaves, current row, and the entire rows of the forest.
 func isRootPositionOnRow(position, numLeaves uint64, row uint8) bool {
 	rootPresent := numLeaves&(1<<row) != 0
-	rootPos := rootPosition(numLeaves, row, treeRows(numLeaves))
+	rootPos := rootPosition(numLeaves, row, TreeRows(numLeaves))
 
 	return rootPresent && rootPos == position
 }
@@ -151,8 +151,8 @@ func isRootPositionOnRow(position, numLeaves uint64, row uint8) bool {
 // isRootPositionOnRowTotalRows is a wrapper around isRootPositionOnRow that will translate the given
 // position if needed.
 func isRootPositionOnRowTotalRows(position, numLeaves uint64, row, forestRows uint8) bool {
-	if treeRows(numLeaves) != forestRows {
-		translated := translatePos(position, forestRows, treeRows(numLeaves))
+	if TreeRows(numLeaves) != forestRows {
+		translated := translatePos(position, forestRows, TreeRows(numLeaves))
 		return isRootPositionOnRow(translated, numLeaves, row)
 	}
 
@@ -334,7 +334,7 @@ func getLowestRoot(numLeaves uint64, totalRows uint8) uint8 {
 // 2. The height from node to its tree top (which is the bitfield length).
 // 3. The L/R bitfield to descend to the node.
 func detectOffset(position uint64, numLeaves uint64) (uint8, uint8, uint64, error) {
-	tRows := int(treeRows(numLeaves))
+	tRows := int(TreeRows(numLeaves))
 	// nr = target node row
 	nr := detectRow(position, uint8(tRows))
 
@@ -388,7 +388,7 @@ func detectOffset(position uint64, numLeaves uint64) (uint8, uint8, uint64, erro
 	return biggerTrees, uint8(tRows) - nr, ^position, nil
 }
 
-// treeRows returns the number of rows given n leaves.
+// TreeRows returns the number of rows given n leaves.
 // Example: The below tree will return 2 as the forest will allocate enough for
 // 4 leaves.
 //
@@ -397,7 +397,7 @@ func detectOffset(position uint64, numLeaves uint64) (uint8, uint8, uint64, erro
 // row 1: 04
 // .      |---\   |---\
 // row 0: 00  01  02
-func treeRows(n uint64) uint8 {
+func TreeRows(n uint64) uint8 {
 	if n == 0 {
 		return 0
 	}
@@ -712,7 +712,7 @@ func getRootPosition(position uint64, numLeaves uint64, forestRows uint8) (uint6
 // AllSubTreesToString returns a string of all the individual subtrees in the accumulator.
 func AllSubTreesToString(ts ToString) string {
 	str := ""
-	totalRows := treeRows(ts.GetNumLeaves())
+	totalRows := TreeRows(ts.GetNumLeaves())
 	for h := uint8(0); h < totalRows; h++ {
 		rootPos := rootPosition(ts.GetNumLeaves(), h, totalRows)
 		if isRootPosition(rootPos, ts.GetNumLeaves()) {
@@ -726,11 +726,11 @@ func AllSubTreesToString(ts ToString) string {
 
 // SubTreeToString returns a string of the subtree that the position is in.
 func SubTreeToString(ts ToString, position uint64, inHex bool) string {
-	rootPosition, err := getRootPosition(position, ts.GetNumLeaves(), treeRows(ts.GetNumLeaves()))
+	rootPosition, err := getRootPosition(position, ts.GetNumLeaves(), TreeRows(ts.GetNumLeaves()))
 	if err != nil {
 		return fmt.Sprintf("SubTreeToString error: %v", err.Error())
 	}
-	subTreeRow := detectRow(rootPosition, treeRows(ts.GetNumLeaves()))
+	subTreeRow := detectRow(rootPosition, TreeRows(ts.GetNumLeaves()))
 
 	if subTreeRow > 7 {
 		s := fmt.Sprintf("Can't print subtree with rows %d. roots:\n", subTreeRow)
@@ -785,7 +785,7 @@ func SubTreeToString(ts ToString, position uint64, inHex bool) string {
 				}
 			}
 
-			leftChild := leftChild(position, treeRows(ts.GetNumLeaves()))
+			leftChild := leftChild(position, TreeRows(ts.GetNumLeaves()))
 			rightChild := rightSib(leftChild)
 			nextPositions = append(nextPositions, leftChild)
 			nextPositions = append(nextPositions, rightChild)

--- a/utils_test.go
+++ b/utils_test.go
@@ -93,9 +93,9 @@ func TestRootPositions(t *testing.T) {
 		{numLeaves: 2, totalRows: 1},
 		{numLeaves: 15, totalRows: 50},
 		{numLeaves: 4454546, totalRows: 50},
-		{numLeaves: 4454546, totalRows: treeRows(4454546)},
+		{numLeaves: 4454546, totalRows: TreeRows(4454546)},
 		{numLeaves: 111875, totalRows: 50},
-		{numLeaves: 111875, totalRows: treeRows(111875)},
+		{numLeaves: 111875, totalRows: TreeRows(111875)},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
treeRows is exported as it's required for clients that are calculating which proof positions they need to download.