### PR TITLE
prove, testdata: add caching scheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module github.com/utreexo/utreexo
 go 1.21
 
 require golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd h1:zVFyTKZN/Q7mNRWSs1GOYnHM9NiFSJ54YVRsD0rNWT4=
 golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/testdata/fuzz/FuzzAddBlockSummary/022a498bd055a925
+++ b/testdata/fuzz/FuzzAddBlockSummary/022a498bd055a925
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1)
+uint32(7)
+int64(-77)

--- a/utils.go
+++ b/utils.go
@@ -955,6 +955,17 @@ func uint64Cmp(a, b uint64) int {
 	return 0
 }
 
+// uint64Descending compares two uint64 values and returns 1 is a is smaller than b.
+// This results in the slice being sorted in descending order.
+func uint64Descending(a, b uint64) int {
+	if a > b {
+		return -1
+	} else if a < b {
+		return 1
+	}
+	return 0
+}
+
 // intLess is a helper function that is useful for using sorting.
 func intLess(a, b int) bool {
 	return a < b


### PR DESCRIPTION
CachingScheduleTracker takes in block summary information and is able to
generate a clairvoyant caching schedule. The code included here is the
code for taking in block summaries and generating the zombie root
information.