### PR TITLE
prove: add undo code for []uint64

### DIFF
--- a/testdata/fuzz/FuzzGetPrevPos/006c26a74154d611
+++ b/testdata/fuzz/FuzzGetPrevPos/006c26a74154d611
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(751)
+uint32(3)
+int64(316)

--- a/testdata/fuzz/FuzzGetPrevPos/19a57a9acf324b37
+++ b/testdata/fuzz/FuzzGetPrevPos/19a57a9acf324b37
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(3)
+int64(150)

--- a/testdata/fuzz/FuzzGetPrevPos/5de3dd5bd991236d
+++ b/testdata/fuzz/FuzzGetPrevPos/5de3dd5bd991236d
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(3)
+uint32(3)
+int64(145)

--- a/testdata/fuzz/FuzzGetPrevPos/791bb5f4000a1a44
+++ b/testdata/fuzz/FuzzGetPrevPos/791bb5f4000a1a44
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(1280)
+uint32(3)
+int64(368)

--- a/testdata/fuzz/FuzzGetPrevPos/b870be6781b1f1b1
+++ b/testdata/fuzz/FuzzGetPrevPos/b870be6781b1f1b1
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(713)
+uint32(7)
+int64(471)


### PR DESCRIPTION
Because we go backwards, we must be able to calculate the original positions of the deletions. The following code is added here.