### PR TITLE
mappollard: add LeafInfo for the cached leaves

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -1164,6 +1164,11 @@ func (m *MapPollard) Ingest(delHashes []Hash, proof Proof) error {
 //
 // This function is different from Ingest() in that it's not safe for concurrent access.
 func (m *MapPollard) ingest(delHashes []Hash, proof Proof) error {
+	// Nothing to ingest if we already have everything.
+	if m.Full {
+		return nil
+	}
+
 	hnp := toHashAndPos(proof.Targets, delHashes)
 	if m.TotalRows != TreeRows(m.NumLeaves) {
 		hnp.positions = translatePositions(hnp.positions, TreeRows(m.NumLeaves), m.TotalRows)
@@ -1197,9 +1202,6 @@ func (m *MapPollard) ingest(delHashes []Hash, proof Proof) error {
 	// Ingest the targets and the intermediate positions and their hashes.
 	for i, pos := range intermediate.positions {
 		remember := false
-		if m.Full {
-			remember = true
-		}
 		for i := range hnp.positions {
 			if hnp.positions[i] == pos {
 				remember = true

--- a/mappollard.go
+++ b/mappollard.go
@@ -160,6 +160,9 @@ type MapPollard struct {
 	// accumulator.
 	NumLeaves uint64
 
+	// CurrentModifies counts how many modifies the pollard has had.
+	CurrentModifies uint32
+
 	// TotalRows is the number of rows the accumulator has allocated for.
 	TotalRows uint8
 
@@ -197,6 +200,8 @@ func (m *MapPollard) Modify(adds []Leaf, delHashes []Hash, proof Proof) error {
 	if err != nil {
 		return err
 	}
+
+	m.CurrentModifies++
 
 	return nil
 }
@@ -924,6 +929,8 @@ func (m *MapPollard) Undo(numAdds uint64, proof Proof, hashes, origPrevRoots []H
 		}
 		m.Nodes.Put(rootPos[i], Leaf{Hash: origPrevRoots[i], Remember: remember})
 	}
+
+	m.CurrentModifies--
 
 	return nil
 }

--- a/testdata/fuzz/FuzzMapPollardTTLs/c369cd12dfc951ce
+++ b/testdata/fuzz/FuzzMapPollardTTLs/c369cd12dfc951ce
@@ -1,0 +1,4 @@
+go test fuzz v1
+uint32(675)
+uint32(53)
+int64(90)


### PR DESCRIPTION
For bridge nodes, caching leaves with their creat height and index is useful
for generating TTLs for additions. The added methods `ModifyAndReturnTTLs`
and `UndoWithTTLs` allow callers to take advantage of the added in LeafInfo
for each of the cached leaves.