### PR TITLE
pollard, mappollard, accumulator_interface: update accumulator interface for Undo

### DIFF
--- a/accumulator_interface.go
+++ b/accumulator_interface.go
@@ -16,7 +16,7 @@ type Utreexo interface {
 	Verify(delHashes []Hash, proof Proof, remember bool) error
 
 	// Undo reverts a modification done by Modify.
-	Undo(numAdds uint64, proof Proof, delHashes, prevRoots []Hash) error
+	Undo(prevAdds []Hash, proof Proof, delHashes, prevRoots []Hash) error
 
 	// GetRoots returns the current roots of the accumulator.
 	GetRoots() []Hash

--- a/mappollard.go
+++ b/mappollard.go
@@ -992,11 +992,11 @@ func (m *MapPollard) UndoWithTTLs(numAdds uint64, createIndex []uint32,
 
 // Undo will undo the last modify. The numAdds, proof, hashes, MUST be the data from the previous modify.
 // The origPrevRoots MUST be the roots that this Undo will go back to.
-func (m *MapPollard) Undo(numAdds uint64, proof Proof, hashes, origPrevRoots []Hash) error {
+func (m *MapPollard) Undo(adds []Hash, proof Proof, hashes, origPrevRoots []Hash) error {
 	m.rwLock.Lock()
 	defer m.rwLock.Unlock()
 
-	err := m.undoAdd(numAdds, proof.Targets, origPrevRoots)
+	err := m.undoAdd(uint64(len(adds)), proof.Targets, origPrevRoots)
 	if err != nil {
 		return fmt.Errorf("Undo errored while undoing added leaves. %v", err)
 	}

--- a/pollard.go
+++ b/pollard.go
@@ -338,11 +338,11 @@ func (p *Pollard) deleteFromMap(delHashes []Hash) {
 //
 // Ex: If the caller is trying to go back to block 9, the numAdds, dels, and delHashes should be
 // the adds and dels that happened to get to block 10. prevRoots should be the roots at block 9.
-func (p *Pollard) Undo(numAdds uint64, proof Proof, delHashes []Hash, prevRoots []Hash) error {
-	for i := 0; i < int(numAdds); i++ {
+func (p *Pollard) Undo(prevAdds []Hash, proof Proof, delHashes []Hash, prevRoots []Hash) error {
+	for i := 0; i < len(prevAdds); i++ {
 		p.undoSingleAdd()
 	}
-	err := p.undoEmptyRoots(numAdds, proof.Targets, prevRoots)
+	err := p.undoEmptyRoots(uint64(len(prevAdds)), proof.Targets, prevRoots)
 	if err != nil {
 		return err
 	}

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -231,7 +231,7 @@ func testUndo(t *testing.T, utreexo UtreexoTest) {
 		}
 
 		// Perform the undo.
-		err = utreexo.Undo(uint64(len(test.modifyAdds)), modifyProof, test.modifyDels, beforeRoots)
+		err = utreexo.Undo(test.modifyAdds, modifyProof, test.modifyDels, beforeRoots)
 		if err != nil {
 			err := fmt.Errorf("TestUndo failed %d: error %v"+
 				"\nbefore:\n\n%s"+
@@ -915,7 +915,11 @@ func fuzzUndo(t *testing.T, p UtreexoTest, startLeaves uint8, modifyAdds uint8, 
 	afterStr := p.String()
 	afterMap := p.nodeMapToString()
 
-	err = p.Undo(uint64(modifyAdds), bp, dels, beforeRoots)
+	modifyAddHashes := make([]Hash, len(modifyLeaves))
+	for i, modifyAdd := range modifyLeaves {
+		modifyAddHashes[i] = modifyAdd.Hash
+	}
+	err = p.Undo(modifyAddHashes, bp, dels, beforeRoots)
 	if err != nil {
 		startHashes := make([]Hash, len(leaves))
 		for i, leaf := range leaves {
@@ -1182,7 +1186,11 @@ func fuzzUndoChain(t *testing.T, p UtreexoTest, blockCount, numAdds, duration ui
 				copy(copyProof.Targets, undoData[i].proof.Targets)
 				copy(copyProof.Proof, undoData[i].proof.Proof)
 
-				err := p.Undo(uint64(len(undoData[i].adds)), copyProof, undoData[i].hashes, undoData[i].prevRoots)
+				addHashes := make([]Hash, len(undoData[i].adds))
+				for j, add := range undoData[i].adds {
+					addHashes[j] = add.Hash
+				}
+				err := p.Undo(addHashes, copyProof, undoData[i].hashes, undoData[i].prevRoots)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/prove_test.go
+++ b/prove_test.go
@@ -670,7 +670,7 @@ func FuzzModifyProofChain(f *testing.F) {
 				t.Fatalf("FuzzModifyProof fail at block %d. Error: %v", b, err)
 			}
 
-			err = p.Undo(uint64(len(adds)), blockProof, delHashes, stump.Roots)
+			err = p.Undo(addHashes, blockProof, delHashes, stump.Roots)
 			if err != nil {
 				t.Fatalf("FuzzModifyProof fail at block %d. Error: %v", b, err)
 			}


### PR DESCRIPTION
Undo now takes in the acutal hashes instead of just the numAdds. This makes it easier to reason about undoing the adds.