### PR TITLE
stump, utils: support adding empty hashes

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,13 @@ import (
 
 // parentHash returns the hash of the left and right hashes passed in.
 func parentHash(l, r Hash) Hash {
+	if l == empty {
+		return r
+	}
+	if r == empty {
+		return l
+	}
+
 	h := sha512.New512_256()
 	h.Write(l[:])
 	h.Write(r[:])


### PR DESCRIPTION
For the accumulator, operations of these elements result in the same roots:

add(empty, 2, 3, 4)
add(1, 2, 3, 4), delete(1)

In order to support the first version, we enable the support to add empty hashes correctly with Stump.