### PR TITLE
mappollard: add InitWithStump

### DIFF
--- a/mappollard.go
+++ b/mappollard.go
@@ -1184,6 +1184,25 @@ func newNodesMap(prealloc int) *NodesMap {
 	return &NodesMap{m: make(map[Hash]Node, prealloc)}
 }
 
+// InitWithStump allows a MapPollard to be ready for use based off of the roots and
+// numleaves from the stump.
+func InitWithStump(s Stump) *MapPollard {
+	mp := NewMapPollard(false)
+
+	for _, root := range s.Roots {
+		node := Node{
+			Remember: false,
+			AddIndex: -1,
+		}
+		mp.Nodes.Put(root, node)
+	}
+
+	mp.Roots = s.Roots
+	mp.NumLeaves = s.NumLeaves
+
+	return &mp
+}
+
 // MapPollard is an implementation of the utreexo accumulators that supports pollard
 // functionality.
 type MapPollard struct {


### PR DESCRIPTION
For MapPollard, if you want to initialize based on a specific height, you can't just set the roots and the numleaves. You also need access to the internal nodes maps in order for Modify to function correctly.

This new helper function allows an external caller to init a MapPollard properly from a Stump.