### PR TITLE
swisstable: add swisstable positionMap

### DIFF
--- a/internal/swisstable/mmap_linux.go
+++ b/internal/swisstable/mmap_linux.go
@@ -1,0 +1,7 @@
+package swisstable
+
+import "syscall"
+
+// mmapFlags are the flags passed to syscall.Mmap for shared, read-write mappings.
+// MAP_POPULATE pre-faults pages on Linux, avoiding page faults on first access.
+const mmapFlags = syscall.MAP_SHARED | syscall.MAP_POPULATE

--- a/internal/swisstable/mmap_other.go
+++ b/internal/swisstable/mmap_other.go
@@ -1,0 +1,9 @@
+//go:build unix && !linux
+
+package swisstable
+
+import "syscall"
+
+// mmapFlags are the flags passed to syscall.Mmap for shared, read-write mappings.
+// MAP_POPULATE is Linux-only, so other platforms use MAP_SHARED alone.
+const mmapFlags = syscall.MAP_SHARED

--- a/internal/swisstable/swisstable.go
+++ b/internal/swisstable/swisstable.go
@@ -1,0 +1,634 @@
+//go:build unix
+
+package swisstable
+
+// SwissPositionMap is a disk-backed hash table using the Swiss Table algorithm.
+//
+// Design:
+//   - Maps 32-byte hashes to 8-byte packed positions
+//   - Uses mmap'd files for persistence (ctrl bytes + slots)
+//   - Hashes are NOT stored in the table; lookups verify by reading from dataFile
+//   - Automatically resizes (doubles) when full
+//
+// Memory layout:
+//   - ctrl file: 1 byte per slot (control byte)
+//   - slots file: 8 bytes per slot (packed position)
+//   - Total: 9 bytes per slot, ~13 bytes per entry at 70% load
+//
+// Control byte encoding:
+//   - 0b00000000: empty slot
+//   - 0b01111111: deleted slot (tombstone)
+//   - 0b1xxxxxxx: full slot, lower 7 bits are H2 (secondary hash)
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/bits"
+	"os"
+	"syscall"
+)
+
+// Control byte constants.
+const (
+	groupSize   = 16         // slots per group (SIMD register width)
+	ctrlEmpty   = 0b00000000 // empty slot
+	ctrlDeleted = 0b01111111 // deleted slot (tombstone)
+	ctrlFull    = 0b10000000 // high bit set = full, lower 7 bits = H2
+
+	// fileHeaderSize is the size of the header in ctrl and slots files (stores consistency hash)
+	fileHeaderSize = 32 // 32-byte hash for consistency check with WAL
+)
+
+// SwissPositionMap is a Swiss Table mapping hashes to positions.
+//
+// It is NOT safe for concurrent use. Callers must synchronize access
+// when multiple goroutines may call Get, Set, or Delete concurrently.
+// Concurrent read-only access (Get) is safe.
+type SwissPositionMap struct {
+	// Mmap'd data
+	ctrlMmap  []byte // full mmap including header
+	ctrl      []byte // control bytes (1 per slot), points into ctrlMmap after header
+	slotsMmap []byte // full mmap including header
+	slots     []byte // packed positions (8 bytes per slot), points into slotsMmap after header
+
+	// File handles for mmap
+	ctrlFile  *os.File
+	slotsFile *os.File
+	ctrlPath  string
+	slotsPath string
+
+	// Table sizing
+	numSlots  uint64
+	numGroups uint64 // numSlots / groupSize
+
+	// For hash verification (we don't store hashes, we verify from source)
+	dataFile io.ReaderAt
+	posMask  uint64 // mask to extract position from packed value
+
+	// Entry count
+	count uint64
+}
+
+// ----------------------------------------------------------------------------
+// Constructor
+// ----------------------------------------------------------------------------
+
+// NewSwissPositionMap creates a new Swiss Table backed by mmap'd files.
+// Returns the map and a bool indicating if rebuild is needed (consistency hash mismatch).
+// Pass a zero hash to force rebuild. posMask is applied to packed values to
+// extract the leaf position for hash verification against dataFile.
+func NewSwissPositionMap(ctrlPath, slotsPath string, expectedEntries uint64, consistencyHash [32]byte, dataFile io.ReaderAt, posMask uint64) (*SwissPositionMap, bool, error) {
+	if dataFile == nil {
+		return nil, false, fmt.Errorf("dataFile must not be nil")
+	}
+
+	// Size for ~70% load factor, rounded up to a multiple of groupSize.
+	numSlots := max(roundUpGroupSize(expectedEntries*10/7), groupSize)
+	if numSlots > 1<<33 {
+		return nil, false, fmt.Errorf("expectedEntries %d exceeds maximum", expectedEntries)
+	}
+
+	ctrlFile, slotsFile, ctrlMmap, slotsBytes, needsRebuild, err := openFiles(ctrlPath, slotsPath, numSlots, consistencyHash)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// ctrl and slot bytes start after header
+	ctrl := ctrlMmap[fileHeaderSize:]
+	slots := slotsBytes[fileHeaderSize:]
+
+	m := &SwissPositionMap{
+		ctrlMmap:  ctrlMmap,
+		ctrl:      ctrl,
+		slotsMmap: slotsBytes,
+		slots:     slots,
+		ctrlFile:  ctrlFile,
+		slotsFile: slotsFile,
+		ctrlPath:  ctrlPath,
+		slotsPath: slotsPath,
+		numSlots:  numSlots,
+		numGroups: numSlots / groupSize,
+		dataFile:  dataFile,
+		posMask:   posMask,
+	}
+
+	// Restore count from existing data if not rebuilding
+	if !needsRebuild {
+		for _, c := range ctrl {
+			if c&ctrlFull != 0 {
+				m.count++
+			}
+		}
+	}
+
+	return m, needsRebuild, nil
+}
+
+// openFiles opens and mmaps the ctrl and slots files, wiping both if either
+// is inconsistent. Returns needsRebuild=true if files were wiped (hash
+// mismatch, size mismatch, or zero consistency hash).
+func openFiles(ctrlPath, slotsPath string, numSlots uint64, consistencyHash [32]byte) (
+	ctrlFile, slotsFile *os.File, ctrlMmap, slotsBytes []byte, needsRebuild bool, err error) {
+
+	ctrlSize := int64(fileHeaderSize + numSlots)
+	slotsSize := int64(fileHeaderSize + numSlots*8)
+
+	// Open both files.
+	ctrlFile, err = os.OpenFile(ctrlPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, nil, nil, nil, false, fmt.Errorf("open ctrl: %w", err)
+	}
+	slotsFile, err = os.OpenFile(slotsPath, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		ctrlFile.Close()
+		return nil, nil, nil, nil, false, fmt.Errorf("open slots: %w", err)
+	}
+
+	// Check whether existing files are consistent: both must have the
+	// expected size, the consistency hash must be non-zero, and the stored
+	// hash must match.
+	ctrlFi, err := ctrlFile.Stat()
+	if err != nil {
+		ctrlFile.Close()
+		slotsFile.Close()
+		return nil, nil, nil, nil, false, err
+	}
+	slotsFi, err := slotsFile.Stat()
+	if err != nil {
+		ctrlFile.Close()
+		slotsFile.Close()
+		return nil, nil, nil, nil, false, err
+	}
+
+	needsRebuild = true
+	var ctrlHash, slotsHash [32]byte
+	ctrlFile.ReadAt(ctrlHash[:], 0)
+	slotsFile.ReadAt(slotsHash[:], 0)
+	if consistencyHash != [32]byte{} &&
+		ctrlFi.Size() == ctrlSize &&
+		slotsFi.Size() == slotsSize &&
+		ctrlHash == consistencyHash &&
+		slotsHash == consistencyHash {
+		needsRebuild = false
+	}
+
+	// If rebuild needed, wipe both files so the OS provides fresh
+	// zero-filled pages with no stale ctrl or slot data.
+	if needsRebuild {
+		for _, wipe := range []struct {
+			f    *os.File
+			size int64
+			name string
+		}{
+			{ctrlFile, ctrlSize, "ctrl"},
+			{slotsFile, slotsSize, "slots"},
+		} {
+			if err := wipe.f.Truncate(0); err != nil {
+				ctrlFile.Close()
+				slotsFile.Close()
+				return nil, nil, nil, nil, false, fmt.Errorf("truncate %s: %w", wipe.name, err)
+			}
+			if err := wipe.f.Truncate(wipe.size); err != nil {
+				ctrlFile.Close()
+				slotsFile.Close()
+				return nil, nil, nil, nil, false, fmt.Errorf("extend %s: %w", wipe.name, err)
+			}
+		}
+	}
+
+	// Mmap both files.
+	ctrlMmap, err = syscall.Mmap(int(ctrlFile.Fd()), 0, int(ctrlSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, mmapFlags)
+	if err != nil {
+		ctrlFile.Close()
+		slotsFile.Close()
+		return nil, nil, nil, nil, false, fmt.Errorf("mmap ctrl: %w", err)
+	}
+	slotsBytes, err = syscall.Mmap(int(slotsFile.Fd()), 0, int(slotsSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, mmapFlags)
+	if err != nil {
+		syscall.Munmap(ctrlMmap)
+		ctrlFile.Close()
+		slotsFile.Close()
+		return nil, nil, nil, nil, false, fmt.Errorf("mmap slots: %w", err)
+	}
+
+	return ctrlFile, slotsFile, ctrlMmap, slotsBytes, needsRebuild, nil
+}
+
+// roundUpGroupSize rounds n up to the nearest multiple of groupSize.
+func roundUpGroupSize(n uint64) uint64 {
+	return ((n + groupSize - 1) / groupSize) * groupSize
+}
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+// Get looks up a hash and returns its packed position.
+func (m *SwissPositionMap) Get(hash [32]byte) (uint64, bool, error) {
+	h1, h2 := splitHash(hash)
+	start := h1 % m.numGroups
+
+	for i := range m.numGroups {
+		base := m.groupBase(start, i)
+		// Check slots with matching H2
+		for matches := m.matchH2(base, h2); matches != 0; matches &= matches - 1 {
+			slot := base + uint64(bits.TrailingZeros16(matches))
+			packed := m.getSlot(slot)
+			ok, err := m.verifyHash(packed, hash)
+			if err != nil {
+				return 0, false, fmt.Errorf("swiss get: %w", err)
+			}
+			if ok {
+				return packed, true, nil
+			}
+		}
+
+		// Empty slot means key doesn't exist
+		if m.hasEmpty(base) {
+			return 0, false, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// Set stores a hash -> packed position mapping, resizing the table if needed.
+func (m *SwissPositionMap) Set(hash [32]byte, packed uint64) error {
+	// Resize before inserting if load factor would exceed 70%.
+	if (m.count+1)*10 > m.numSlots*7 {
+		if err := m.resize(); err != nil {
+			return err
+		}
+	}
+
+	return m.set(hash, packed)
+}
+
+// set inserts or updates a hash -> packed position mapping without checking
+// the load factor.
+func (m *SwissPositionMap) set(hash [32]byte, packed uint64) error {
+	h1, h2 := splitHash(hash)
+	start := h1 % m.numGroups
+
+	// Track first available slot for insertion. We must complete the full
+	// probe sequence (stopping only at empty, not deleted) to avoid inserting
+	// a duplicate when the key exists in a later group.
+	firstAvail := uint64(0)
+	hasAvail := false
+
+	for i := range m.numGroups {
+		base := m.groupBase(start, i)
+
+		// Check if key exists (update in place)
+		for matches := m.matchH2(base, h2); matches != 0; matches &= matches - 1 {
+			slot := base + uint64(bits.TrailingZeros16(matches))
+			ok, err := m.verifyHash(m.getSlot(slot), hash)
+			if err != nil {
+				return fmt.Errorf("swiss set: %w", err)
+			}
+			if ok {
+				m.setSlot(slot, packed)
+				return nil
+			}
+		}
+
+		// Remember first available slot, but don't insert yet
+		if !hasAvail {
+			if avail := m.matchEmptyOrDeleted(base); avail != 0 {
+				firstAvail = base + uint64(bits.TrailingZeros16(avail))
+				hasAvail = true
+			}
+		}
+
+		// Empty slot means the key definitely doesn't exist further
+		if m.hasEmpty(base) {
+			break
+		}
+	}
+
+	if !hasAvail {
+		return fmt.Errorf("swiss table: no available slot (count=%d, slots=%d)", m.count, m.numSlots)
+	}
+
+	m.ctrl[firstAvail] = h2
+	m.setSlot(firstAvail, packed)
+	m.count++
+	return nil
+}
+
+// Delete removes a hash from the table.
+//
+// Note: Delete leaves a tombstone (ctrlDeleted) which can degrade probe
+// performance if tombstones accumulate without a resize to clear them.
+// In practice this is not a concern because Delete is only called during
+// Undo (block disconnects), which is rare.
+func (m *SwissPositionMap) Delete(hash [32]byte) (bool, error) {
+	h1, h2 := splitHash(hash)
+	start := h1 % m.numGroups
+
+	for i := range m.numGroups {
+		base := m.groupBase(start, i)
+
+		for matches := m.matchH2(base, h2); matches != 0; matches &= matches - 1 {
+			slot := base + uint64(bits.TrailingZeros16(matches))
+			ok, err := m.verifyHash(m.getSlot(slot), hash)
+			if err != nil {
+				return false, fmt.Errorf("swiss delete: %w", err)
+			}
+			if ok {
+				m.ctrl[slot] = ctrlDeleted
+				m.clearSlot(slot)
+				m.count--
+				return true, nil
+			}
+		}
+
+		if m.hasEmpty(base) {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// Count returns the number of entries.
+func (m *SwissPositionMap) Count() uint64 {
+	return m.count
+}
+
+// ForEach iterates over all entries.
+func (m *SwissPositionMap) ForEach(fn func(packed uint64)) {
+	for i, c := range m.ctrl {
+		if c&ctrlFull != 0 {
+			fn(m.getSlot(uint64(i)))
+		}
+	}
+}
+
+// Close unmaps and closes files.
+func (m *SwissPositionMap) Close() error {
+	var errs []error
+	if m.ctrlMmap != nil {
+		if err := syscall.Munmap(m.ctrlMmap); err != nil {
+			errs = append(errs, fmt.Errorf("munmap ctrl: %w", err))
+		}
+	}
+	if m.slotsMmap != nil {
+		if err := syscall.Munmap(m.slotsMmap); err != nil {
+			errs = append(errs, fmt.Errorf("munmap slots: %w", err))
+		}
+	}
+	if m.ctrlFile != nil {
+		if err := m.ctrlFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close ctrl: %w", err))
+		}
+	}
+	if m.slotsFile != nil {
+		if err := m.slotsFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close slots: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// SetConsistencyHash updates the stored hash in the ctrl and slots file
+// headers and flushes the mmap to disk. Call this after WAL flush succeeds
+// to enable skipping rebuild on restart.
+func (m *SwissPositionMap) SetConsistencyHash(hash [32]byte) error {
+	// Flush mmap'd ctrl and slot data to disk before writing the consistency
+	// hash. The hash acts as a "valid" marker, so all data must be durable
+	// first. On Linux, fsync on the fd flushes MAP_SHARED dirty pages.
+	if err := m.slotsFile.Sync(); err != nil {
+		return fmt.Errorf("sync slots: %w", err)
+	}
+	if err := m.ctrlFile.Sync(); err != nil {
+		return fmt.Errorf("sync ctrl: %w", err)
+	}
+	// Write through the fd (not the mmap) so that File.Sync is guaranteed
+	// to flush the header data.
+	if _, err := m.ctrlFile.WriteAt(hash[:], 0); err != nil {
+		return fmt.Errorf("write ctrl consistency hash: %w", err)
+	}
+	if _, err := m.slotsFile.WriteAt(hash[:], 0); err != nil {
+		return fmt.Errorf("write slots consistency hash: %w", err)
+	}
+	if err := m.ctrlFile.Sync(); err != nil {
+		return fmt.Errorf("sync ctrl hash: %w", err)
+	}
+	return m.slotsFile.Sync()
+}
+
+// ----------------------------------------------------------------------------
+// Internal: Hashing
+// ----------------------------------------------------------------------------
+
+// groupBase returns the byte offset of the i-th group in a linear probe
+// sequence starting from the given group index. Each group has 16 slots,
+// so at most 16 comparisons per group visited.
+func (m *SwissPositionMap) groupBase(start, i uint64) uint64 {
+	return ((start + i) % m.numGroups) * groupSize
+}
+
+// splitHash returns H1 (bucket index) and H2 (control byte).
+// H1 is the first 8 bytes of the hash (used for group selection) and H2 is
+// derived from byte 9 (7-bit fingerprint with high bit set). Since this map
+// is only used for leaves that are already uniquely hashed, we don't need to
+// worry about too many collisions happening.
+func splitHash(hash [32]byte) (h1 uint64, h2 byte) {
+	h1 = binary.LittleEndian.Uint64(hash[:8])
+	h2 = (hash[8] & 0x7F) | ctrlFull // high bit set + 7-bit fingerprint
+	return
+}
+
+// verifyHash reads the hash at the position encoded in packed and compares it
+// to expected. The position (extracted via posMask) must correspond to a
+// valid 32-byte hash entry in dataFile at offset position*32.
+func (m *SwissPositionMap) verifyHash(packed uint64, expected [32]byte) (bool, error) {
+	var buf [32]byte
+	pos := packed & m.posMask
+	if _, err := m.dataFile.ReadAt(buf[:], int64(pos*32)); err != nil {
+		return false, fmt.Errorf("read hash at position %d: %w", pos, err)
+	}
+	return buf == expected, nil
+}
+
+// ----------------------------------------------------------------------------
+// Internal: Group matching (SIMD on amd64, scalar fallback in swisstable_generic.go)
+// ----------------------------------------------------------------------------
+
+func (m *SwissPositionMap) matchH2(base uint64, h2 byte) uint16 {
+	return matchH2(m.ctrl[base:base+groupSize], h2)
+}
+
+func (m *SwissPositionMap) hasEmpty(base uint64) bool {
+	return matchEmpty(m.ctrl[base:base+groupSize]) != 0
+}
+
+func (m *SwissPositionMap) matchEmptyOrDeleted(base uint64) uint16 {
+	return matchEmptyOrDeleted(m.ctrl[base : base+groupSize])
+}
+
+// ----------------------------------------------------------------------------
+// Internal: Slot access
+// ----------------------------------------------------------------------------
+
+func (m *SwissPositionMap) getSlot(i uint64) uint64 {
+	return binary.LittleEndian.Uint64(m.slots[i*8:])
+}
+
+func (m *SwissPositionMap) setSlot(i uint64, val uint64) {
+	binary.LittleEndian.PutUint64(m.slots[i*8:], val)
+}
+
+func (m *SwissPositionMap) clearSlot(i uint64) {
+	binary.LittleEndian.PutUint64(m.slots[i*8:], 0)
+}
+
+// ----------------------------------------------------------------------------
+// Internal: Resize
+// ----------------------------------------------------------------------------
+
+// rehashInsert inserts a hash->packed mapping into explicit ctrl/slots buffers.
+// It skips duplicate checking because it is only used during resize where the
+// target table is known to be empty. This also avoids depending on m's fields,
+// so the caller can defer updating m until rehash fully succeeds.
+func rehashInsert(ctrl []byte, slots []byte, numGroups uint64, hash [32]byte, packed uint64) error {
+	h1, h2 := splitHash(hash)
+	start := h1 % numGroups
+
+	for i := range numGroups {
+		base := ((start + i) % numGroups) * groupSize
+		if avail := matchEmpty(ctrl[base : base+groupSize]); avail != 0 {
+			slot := base + uint64(bits.TrailingZeros16(avail))
+			ctrl[slot] = h2
+			binary.LittleEndian.PutUint64(slots[slot*8:], packed)
+			return nil
+		}
+	}
+	return fmt.Errorf("swiss table rehash: no slot available (groups=%d)", numGroups)
+}
+
+// resize doubles the table and rehashes all entries.
+//
+// This operation is not crash-safe in isolation. If the process crashes
+// mid-resize, the on-disk files will contain a partial table. The consistency
+// hash is invalidated before resizing so that a crash triggers a full rebuild
+// from the data file on restart.
+//
+// Rehashing is performed into the new mmaps without updating m's fields first.
+// Only after a successful rehash does the swap occur. On failure the old
+// ctrl/slots are restored from saved copies so the map remains usable for the
+// current session. The zeroed consistency hash ensures rebuild on restart.
+func (m *SwissPositionMap) resize() error {
+	oldNumSlots := m.numSlots
+	newNumSlots := oldNumSlots * 2
+	newNumGroups := newNumSlots / groupSize
+
+	// Copy old data before remapping. Both copies are necessary because
+	// the old and new mmaps share the same underlying file (MAP_SHARED),
+	// so clearing stale ctrl bytes in the new mmap would also zero the
+	// overlapping region visible through the old mmap.
+	oldCtrl := make([]byte, oldNumSlots)
+	copy(oldCtrl, m.ctrl)
+	oldSlots := make([]byte, oldNumSlots*8)
+	copy(oldSlots, m.slots)
+
+	// Invalidate consistency hash before modifying files. If the process
+	// crashes during resize, the zero header ensures rebuild on restart.
+	// Write through the fd (not the mmap) so that File.Sync is guaranteed
+	// to flush the data per POSIX without requiring msync.
+	var zeroHeader [fileHeaderSize]byte
+	if _, err := m.ctrlFile.WriteAt(zeroHeader[:], 0); err != nil {
+		return fmt.Errorf("resize invalidate ctrl header: %w", err)
+	}
+	if _, err := m.slotsFile.WriteAt(zeroHeader[:], 0); err != nil {
+		return fmt.Errorf("resize invalidate slots header: %w", err)
+	}
+	if err := m.ctrlFile.Sync(); err != nil {
+		return fmt.Errorf("resize fsync ctrl: %w", err)
+	}
+	if err := m.slotsFile.Sync(); err != nil {
+		return fmt.Errorf("resize fsync slots: %w", err)
+	}
+
+	// Extend files (both include header)
+	newCtrlFileSize := int64(fileHeaderSize + newNumSlots)
+	if err := m.ctrlFile.Truncate(newCtrlFileSize); err != nil {
+		return fmt.Errorf("resize ctrl: %w", err)
+	}
+	newSlotsFileSize := int64(fileHeaderSize + newNumSlots*8)
+	if err := m.slotsFile.Truncate(newSlotsFileSize); err != nil {
+		return fmt.Errorf("resize slots: %w", err)
+	}
+
+	// Remap (both mmaps include header).
+	// If the second mmap fails, unmap the first to avoid a leak.
+	newCtrlMmap, err := syscall.Mmap(int(m.ctrlFile.Fd()), 0, int(newCtrlFileSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, mmapFlags)
+	if err != nil {
+		return fmt.Errorf("resize ctrl mmap: %w", err)
+	}
+	newSlotsMmap, err := syscall.Mmap(int(m.slotsFile.Fd()), 0, int(newSlotsFileSize),
+		syscall.PROT_READ|syscall.PROT_WRITE, mmapFlags)
+	if err != nil {
+		syscall.Munmap(newCtrlMmap)
+		return fmt.Errorf("resize slots mmap: %w", err)
+	}
+
+	// Slice past headers.
+	newCtrl := newCtrlMmap[fileHeaderSize:]
+	newSlots := newSlotsMmap[fileHeaderSize:]
+
+	// Clear stale ctrl bytes from the old table. Truncate only zero-fills
+	// the extension; the overlapping region retains old ctrlFull/ctrlDeleted
+	// bytes that would appear as ghost entries to rehashInsert and later
+	// lookups.
+	clear(newCtrl)
+
+	// Rehash into the new mmaps WITHOUT updating m's fields. On failure we
+	// restore the old ctrl/slots from saved copies so the map remains usable
+	// for the current session. The zeroed consistency hash ensures a full
+	// rebuild on restart.
+	var count uint64
+	for i, c := range oldCtrl {
+		if c&ctrlFull != 0 {
+			packed := binary.LittleEndian.Uint64(oldSlots[i*8:])
+			var hash [32]byte
+			pos := int64((packed & m.posMask) * 32)
+			if _, err := m.dataFile.ReadAt(hash[:], pos); err != nil {
+				copy(m.ctrl, oldCtrl)
+				copy(m.slots, oldSlots)
+				syscall.Munmap(newCtrlMmap)
+				syscall.Munmap(newSlotsMmap)
+				return fmt.Errorf("resize rehash read: %w", err)
+			}
+			if err := rehashInsert(newCtrl, newSlots, newNumGroups, hash, packed); err != nil {
+				copy(m.ctrl, oldCtrl)
+				copy(m.slots, oldSlots)
+				syscall.Munmap(newCtrlMmap)
+				syscall.Munmap(newSlotsMmap)
+				return fmt.Errorf("resize rehash: %w", err)
+			}
+			count++
+		}
+	}
+
+	// Rehash succeeded — swap to new state and unmap old mmaps.
+	oldCtrlMmap := m.ctrlMmap
+	oldSlotsMmap := m.slotsMmap
+
+	m.ctrlMmap = newCtrlMmap
+	m.ctrl = newCtrl
+	m.slotsMmap = newSlotsMmap
+	m.slots = newSlots
+	m.numSlots = newNumSlots
+	m.numGroups = newNumGroups
+	m.count = count
+
+	syscall.Munmap(oldCtrlMmap)
+	syscall.Munmap(oldSlotsMmap)
+
+	return nil
+}

--- a/internal/swisstable/swisstable_amd64.go
+++ b/internal/swisstable/swisstable_amd64.go
@@ -1,0 +1,21 @@
+//go:build unix && amd64
+
+package swisstable
+
+// matchH2 finds slots matching h2 using SIMD (SSE2).
+// Returns a 16-bit mask where bit i is set if ctrl[i] == h2.
+//
+//go:noescape
+func matchH2(ctrl []byte, h2 byte) uint16
+
+// matchEmpty finds empty slots using SIMD (SSE2).
+// Returns a 16-bit mask where bit i is set if ctrl[i] == 0.
+//
+//go:noescape
+func matchEmpty(ctrl []byte) uint16
+
+// matchEmptyOrDeleted finds empty or deleted slots using SIMD (SSE2).
+// Returns a 16-bit mask where bit i is set if ctrl[i] has high bit = 0.
+//
+//go:noescape
+func matchEmptyOrDeleted(ctrl []byte) uint16

--- a/internal/swisstable/swisstable_amd64.s
+++ b/internal/swisstable/swisstable_amd64.s
@@ -1,0 +1,118 @@
+//go:build unix && amd64
+
+#include "textflag.h"
+
+// ============================================================================
+// Swiss Table SIMD matching functions (SSE2 only)
+// ============================================================================
+//
+// These functions scan 16 control bytes at once using SSE registers.
+// Each returns a 16-bit mask where bit i is set if ctrl[i] matched.
+//
+// Only SSE2 instructions are used, which is baseline for all amd64 CPUs.
+//
+// Go assembly pseudo-registers:
+//   FP = Frame Pointer (arguments from caller)
+//   SP = Stack Pointer (local variables)
+//   SB = Static Base (global symbols)
+//
+// XMM registers (128-bit, holds 16 bytes):
+//   X0, X1, X2, ... are SSE registers
+//
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// func matchH2(ctrl []byte, h2 byte) uint16
+// ----------------------------------------------------------------------------
+// Finds slots where ctrl[i] == h2.
+// Returns 16-bit mask: bit i set if ctrl[i] matches h2.
+//
+// Stack layout (34 bytes total):
+//   +0   ctrl.ptr   (8 bytes)  - pointer to ctrl data
+//   +8   ctrl.len   (8 bytes)  - slice length (unused)
+//   +16  ctrl.cap   (8 bytes)  - slice capacity (unused)
+//   +24  h2         (1 byte)   - the byte to match
+//   +32  return     (2 bytes)  - result mask
+//
+TEXT ·matchH2(SB), NOSPLIT, $0-34
+    // Load arguments
+    MOVQ    ctrl+0(FP), AX          // AX = pointer to ctrl bytes
+    MOVBLZX h2+24(FP), CX           // CX = h2 (zero-extended to 64-bit)
+
+    // Broadcast h2 to all 16 bytes of X1 using SSE2 only:
+    //   MOVD:       X1 = [h2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    //   PUNPCKLBW:  X1 = [h2, h2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    //   PUNPCKLWL:  X1 = [h2, h2, h2, h2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    //   PSHUFD:     X1 = [h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2, h2]
+    MOVD    CX, X1
+    PUNPCKLBW X1, X1
+    PUNPCKLWL X1, X1
+    PSHUFD  $0, X1, X1
+
+    // Compare ctrl bytes against h2
+    //   X0 = 16 ctrl bytes from memory
+    //   PCMPEQB: X0[i] = (X0[i] == X1[i]) ? 0xFF : 0x00
+    MOVOU   (AX), X0                        // X0 = ctrl[0:16]
+    PCMPEQB X1, X0                          // X0[i] = 0xFF if match, 0x00 if not
+
+    // Extract high bit of each byte into a 16-bit mask
+    //   PMOVMSKB: result[i] = X0[i].bit7
+    //   If ctrl[5] matched, X0[5] = 0xFF, so bit 5 of result = 1
+    PMOVMSKB X0, AX                         // AX = 16-bit mask
+
+    // Return
+    MOVW    AX, ret+32(FP)
+    RET
+
+// ----------------------------------------------------------------------------
+// func matchEmpty(ctrl []byte) uint16
+// ----------------------------------------------------------------------------
+// Finds empty slots (ctrl[i] == 0x00).
+// Returns 16-bit mask: bit i set if ctrl[i] is empty.
+//
+// Stack layout (26 bytes total):
+//   +0   ctrl.ptr   (8 bytes)
+//   +8   ctrl.len   (8 bytes)
+//   +16  ctrl.cap   (8 bytes)
+//   +24  return     (2 bytes)
+//
+TEXT ·matchEmpty(SB), NOSPLIT, $0-26
+    MOVQ    ctrl+0(FP), AX          // AX = pointer to ctrl bytes
+
+    // Compare against zero
+    //   PXOR X1, X1 sets X1 = 0 (XOR with self)
+    //   PCMPEQB compares each byte against 0
+    MOVOU   (AX), X0                // X0 = ctrl[0:16]
+    PXOR    X1, X1                  // X1 = [0, 0, 0, ...]
+    PCMPEQB X1, X0                  // X0[i] = 0xFF if ctrl[i] == 0
+
+    // Extract mask
+    PMOVMSKB X0, AX                 // AX = 16-bit mask
+    MOVW    AX, ret+24(FP)
+    RET
+
+// ----------------------------------------------------------------------------
+// func matchEmptyOrDeleted(ctrl []byte) uint16
+// ----------------------------------------------------------------------------
+// Finds empty (0x00) or deleted (0x7F) slots.
+// Both have high bit = 0. Full slots have high bit = 1 (0x80 | h2).
+// Returns 16-bit mask: bit i set if ctrl[i] is empty or deleted.
+//
+// Stack layout (26 bytes total):
+//   +0   ctrl.ptr   (8 bytes)
+//   +8   ctrl.len   (8 bytes)
+//   +16  ctrl.cap   (8 bytes)
+//   +24  return     (2 bytes)
+//
+TEXT ·matchEmptyOrDeleted(SB), NOSPLIT, $0-26
+    MOVQ    ctrl+0(FP), AX          // AX = pointer to ctrl bytes
+
+    // PMOVMSKB extracts the high bit of each byte.
+    // Full slots have high bit = 1, empty/deleted have high bit = 0.
+    // So we extract high bits, then invert to get empty/deleted mask.
+    MOVOU   (AX), X0                // X0 = ctrl[0:16]
+    PMOVMSKB X0, AX                 // AX[i] = ctrl[i].bit7 (1 if full)
+    XORW    $0xFFFF, AX             // Invert: now 1 if empty/deleted
+
+    MOVW    AX, ret+24(FP)
+    RET

--- a/internal/swisstable/swisstable_fallback.go
+++ b/internal/swisstable/swisstable_fallback.go
@@ -1,0 +1,80 @@
+//go:build !unix
+
+package swisstable
+
+import (
+	"io"
+)
+
+// miniHash is the first 12 bytes of a 256 bit hash.
+type miniHash [12]byte
+
+// mini takes the first 12 bytes of a hash and outputs a miniHash.
+func mini(h [32]byte) miniHash {
+	var m miniHash
+	copy(m[:], h[:12])
+	return m
+}
+
+// SwissPositionMap is a simple map-backed fallback for non-unix platforms
+// where mmap is not available. It provides the same public API as the
+// mmap-backed Swiss Table implementation but does not persist to disk.
+type SwissPositionMap struct {
+	m        map[miniHash]uint64
+	dataFile io.ReaderAt
+}
+
+// NewSwissPositionMap creates a new in-memory position map.
+// On non-unix platforms this always returns needsRebuild=true since the
+// map is not persisted.
+func NewSwissPositionMap(ctrlPath, slotsPath string, expectedEntries uint64, consistencyHash [32]byte, dataFile io.ReaderAt, posMask uint64) (*SwissPositionMap, bool, error) {
+	return &SwissPositionMap{
+		m:        make(map[miniHash]uint64, expectedEntries),
+		dataFile: dataFile,
+	}, true, nil
+}
+
+// Get looks up a hash and returns its packed position.
+func (m *SwissPositionMap) Get(hash [32]byte) (uint64, bool, error) {
+	v, ok := m.m[mini(hash)]
+	return v, ok, nil
+}
+
+// Set stores a hash -> packed position mapping.
+func (m *SwissPositionMap) Set(hash [32]byte, packed uint64) error {
+	m.m[mini(hash)] = packed
+	return nil
+}
+
+// Delete removes a hash from the map.
+func (m *SwissPositionMap) Delete(hash [32]byte) (bool, error) {
+	key := mini(hash)
+	if _, ok := m.m[key]; !ok {
+		return false, nil
+	}
+	delete(m.m, key)
+	return true, nil
+}
+
+// Count returns the number of entries.
+func (m *SwissPositionMap) Count() uint64 {
+	return uint64(len(m.m))
+}
+
+// ForEach iterates over all entries.
+func (m *SwissPositionMap) ForEach(fn func(packed uint64)) {
+	for _, v := range m.m {
+		fn(v)
+	}
+}
+
+// Close is a no-op on non-unix platforms.
+func (m *SwissPositionMap) Close() error {
+	return nil
+}
+
+// SetConsistencyHash is a no-op on non-unix platforms since the map
+// is not persisted.
+func (m *SwissPositionMap) SetConsistencyHash(hash [32]byte) error {
+	return nil
+}

--- a/internal/swisstable/swisstable_fallback_test.go
+++ b/internal/swisstable/swisstable_fallback_test.go
@@ -1,0 +1,75 @@
+//go:build !unix
+
+package swisstable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwissPositionMapFallbackBasic(t *testing.T) {
+	m, needsRebuild, err := NewSwissPositionMap("", "", 100, [32]byte{}, nil, 0)
+	require.NoError(t, err)
+	require.True(t, needsRebuild, "fallback always needs rebuild")
+	defer m.Close()
+
+	h1 := [32]byte{1}
+	h2 := [32]byte{2}
+	h3 := [32]byte{3}
+
+	// Set
+	require.NoError(t, m.Set(h1, 10))
+	require.NoError(t, m.Set(h2, 20))
+	require.NoError(t, m.Set(h3, 30))
+	require.Equal(t, uint64(3), m.Count())
+
+	// Get
+	v, ok, err := m.Get(h1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(10), v)
+
+	v, ok, err = m.Get(h2)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(20), v)
+
+	// Get non-existent
+	_, ok, err = m.Get([32]byte{99})
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Delete
+	deleted, err := m.Delete(h2)
+	require.NoError(t, err)
+	require.True(t, deleted)
+	require.Equal(t, uint64(2), m.Count())
+
+	_, ok, err = m.Get(h2)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Delete non-existent
+	deleted, err = m.Delete([32]byte{99})
+	require.NoError(t, err)
+	require.False(t, deleted)
+
+	// ForEach
+	var sum uint64
+	m.ForEach(func(packed uint64) {
+		sum += packed
+	})
+	require.Equal(t, uint64(40), sum) // 10 + 30
+
+	// Update existing
+	require.NoError(t, m.Set(h1, 100))
+	require.Equal(t, uint64(2), m.Count())
+	v, ok, err = m.Get(h1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(100), v)
+
+	// SetConsistencyHash is a no-op
+	require.NoError(t, m.SetConsistencyHash([32]byte{1, 2, 3}))
+}

--- a/internal/swisstable/swisstable_generic.go
+++ b/internal/swisstable/swisstable_generic.go
@@ -1,0 +1,36 @@
+//go:build unix && !amd64
+
+package swisstable
+
+// matchH2 is the generic fallback (no SIMD).
+func matchH2(ctrl []byte, h2 byte) uint16 {
+	var mask uint16
+	for i, c := range ctrl {
+		if c == h2 {
+			mask |= 1 << i
+		}
+	}
+	return mask
+}
+
+// matchEmpty is the generic fallback.
+func matchEmpty(ctrl []byte) uint16 {
+	var mask uint16
+	for i, c := range ctrl {
+		if c == ctrlEmpty {
+			mask |= 1 << i
+		}
+	}
+	return mask
+}
+
+// matchEmptyOrDeleted is the generic fallback.
+func matchEmptyOrDeleted(ctrl []byte) uint16 {
+	var mask uint16
+	for i, c := range ctrl {
+		if c&ctrlFull == 0 { // empty and deleted both have high bit = 0
+			mask |= 1 << i
+		}
+	}
+	return mask
+}

--- a/internal/swisstable/swisstable_test.go
+++ b/internal/swisstable/swisstable_test.go
@@ -1,0 +1,826 @@
+//go:build unix
+
+package swisstable
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test-local position packing constants matching the values used by forest.go.
+const (
+	testPositionBits = 47
+	testPositionMask = (1 << testPositionBits) - 1
+)
+
+// testHashFromInt creates a deterministic hash from an integer for testing.
+func testHashFromInt(n int) [32]byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(n))
+	return sha256.Sum256(buf[:])
+}
+
+// packPosIndex packs a position and add-index into a single uint64.
+func packPosIndex(pos uint64, addIndex int32) uint64 {
+	return (uint64(uint32(addIndex)) << testPositionBits) | (pos & testPositionMask)
+}
+
+func TestMatchH2(t *testing.T) {
+	// helper: build a 16-byte ctrl group filled with `fill`, then
+	// overwrite specific positions with `target`.
+	makeCtrl := func(fill byte, target byte, positions []int) [16]byte {
+		var ctrl [16]byte
+		for i := range ctrl {
+			ctrl[i] = fill
+		}
+		for _, p := range positions {
+			ctrl[p] = target
+		}
+		return ctrl
+	}
+
+	// helper: convert a list of set-bit positions to a uint16 mask.
+	maskFrom := func(positions []int) uint16 {
+		var m uint16
+		for _, p := range positions {
+			m |= 1 << p
+		}
+		return m
+	}
+
+	tests := []struct {
+		name      string
+		ctrl      [16]byte
+		h2        byte
+		wantMatch []int // bit positions expected in the returned mask
+	}{
+		{
+			name:      "no matches when all slots differ",
+			ctrl:      makeCtrl(0b10000000, 0b10000000, nil),
+			h2:        0b10000101,
+			wantMatch: nil,
+		},
+		{
+			name:      "single match at position 0",
+			ctrl:      makeCtrl(0b10000000, 0b10000101, []int{0}),
+			h2:        0b10000101,
+			wantMatch: []int{0},
+		},
+		{
+			name:      "single match at position 15",
+			ctrl:      makeCtrl(0b10000000, 0b10000101, []int{15}),
+			h2:        0b10000101,
+			wantMatch: []int{15},
+		},
+		{
+			name:      "multiple matches",
+			ctrl:      makeCtrl(0b10000000, 0b10000101, []int{0, 5, 15}),
+			h2:        0b10000101,
+			wantMatch: []int{0, 5, 15},
+		},
+		{
+			name:      "all 16 slots match",
+			ctrl:      makeCtrl(0b10000101, 0b10000101, nil),
+			h2:        0b10000101,
+			wantMatch: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+		{
+			name:      "all slots empty - no match for full h2",
+			ctrl:      makeCtrl(0b00000000, 0b00000000, nil),
+			h2:        0b10000101,
+			wantMatch: nil,
+		},
+		{
+			name:      "match minimum full value 0b10000000",
+			ctrl:      makeCtrl(0b11111111, 0b10000000, []int{3, 9}),
+			h2:        0b10000000,
+			wantMatch: []int{3, 9},
+		},
+		{
+			name:      "match maximum full value 0b11111111",
+			ctrl:      makeCtrl(0b10000000, 0b11111111, []int{7, 14}),
+			h2:        0b11111111,
+			wantMatch: []int{7, 14},
+		},
+		{
+			name:      "match h2=0b00000000 finds empty slots",
+			ctrl:      makeCtrl(0b10000000, 0b00000000, []int{2, 10}),
+			h2:        0b00000000,
+			wantMatch: []int{2, 10},
+		},
+		{
+			name: "match among mixed ctrl bytes",
+			ctrl: [16]byte{
+				0b10000101, 0b00000000, 0b01111111, 0b10000101,
+				0b10000000, 0b10000001, 0b10000010, 0b10000101,
+				0b10000011, 0b10000100, 0b10000110, 0b10000111,
+				0b10001000, 0b10001001, 0b10001010, 0b10000101,
+			},
+			h2:        0b10000101,
+			wantMatch: []int{0, 3, 7, 15},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchH2(tc.ctrl[:], tc.h2)
+			require.Equal(t, maskFrom(tc.wantMatch), got)
+		})
+	}
+}
+
+func TestMatchEmpty(t *testing.T) {
+	maskFrom := func(positions []int) uint16 {
+		var m uint16
+		for _, p := range positions {
+			m |= 1 << p
+		}
+		return m
+	}
+
+	fillCtrl := func(val byte) [16]byte {
+		var ctrl [16]byte
+		for i := range ctrl {
+			ctrl[i] = val
+		}
+		return ctrl
+	}
+
+	tests := []struct {
+		name      string
+		ctrl      [16]byte
+		wantMatch []int
+	}{
+		{
+			name:      "all empty",
+			ctrl:      fillCtrl(ctrlEmpty),
+			wantMatch: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+		{
+			name:      "no empty - all full",
+			ctrl:      fillCtrl(0b10000000),
+			wantMatch: nil,
+		},
+		{
+			name:      "no empty - all deleted",
+			ctrl:      fillCtrl(ctrlDeleted),
+			wantMatch: nil,
+		},
+		{
+			name:      "single empty at position 0",
+			ctrl:      func() [16]byte { c := fillCtrl(0b10000000); c[0] = ctrlEmpty; return c }(),
+			wantMatch: []int{0},
+		},
+		{
+			name:      "single empty at position 15",
+			ctrl:      func() [16]byte { c := fillCtrl(0b10000000); c[15] = ctrlEmpty; return c }(),
+			wantMatch: []int{15},
+		},
+		{
+			name:      "two empty slots",
+			ctrl:      func() [16]byte { c := fillCtrl(0b10000000); c[2] = ctrlEmpty; c[10] = ctrlEmpty; return c }(),
+			wantMatch: []int{2, 10},
+		},
+		{
+			name: "empty among deleted and full",
+			ctrl: func() [16]byte {
+				c := fillCtrl(0b10000000)
+				c[1] = ctrlDeleted // deleted - not empty
+				c[4] = ctrlEmpty   // empty
+				c[7] = ctrlDeleted // deleted - not empty
+				c[12] = ctrlEmpty  // empty
+				return c
+			}(),
+			wantMatch: []int{4, 12},
+		},
+		{
+			name: "alternating empty and full",
+			ctrl: func() [16]byte {
+				var c [16]byte
+				for i := range c {
+					if i%2 == 0 {
+						c[i] = ctrlEmpty
+					} else {
+						c[i] = 0b10000101
+					}
+				}
+				return c
+			}(),
+			wantMatch: []int{0, 2, 4, 6, 8, 10, 12, 14},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchEmpty(tc.ctrl[:])
+			require.Equal(t, maskFrom(tc.wantMatch), got)
+		})
+	}
+}
+
+func TestMatchEmptyOrDeleted(t *testing.T) {
+	maskFrom := func(positions []int) uint16 {
+		var m uint16
+		for _, p := range positions {
+			m |= 1 << p
+		}
+		return m
+	}
+
+	fillCtrl := func(val byte) [16]byte {
+		var ctrl [16]byte
+		for i := range ctrl {
+			ctrl[i] = val
+		}
+		return ctrl
+	}
+
+	tests := []struct {
+		name      string
+		ctrl      [16]byte
+		wantMatch []int
+	}{
+		{
+			name:      "all full - no matches",
+			ctrl:      fillCtrl(0b10000000),
+			wantMatch: nil,
+		},
+		{
+			name:      "all empty - all match",
+			ctrl:      fillCtrl(ctrlEmpty),
+			wantMatch: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+		{
+			name:      "all deleted - all match",
+			ctrl:      fillCtrl(ctrlDeleted),
+			wantMatch: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+		{
+			name: "mix of empty and deleted both match",
+			ctrl: func() [16]byte {
+				c := fillCtrl(0b10000000)
+				c[1] = ctrlEmpty
+				c[7] = ctrlDeleted
+				c[14] = ctrlEmpty
+				return c
+			}(),
+			wantMatch: []int{1, 7, 14},
+		},
+		{
+			name: "only deleted slots match",
+			ctrl: func() [16]byte {
+				c := fillCtrl(0b10000000)
+				c[0] = ctrlDeleted
+				c[8] = ctrlDeleted
+				c[15] = ctrlDeleted
+				return c
+			}(),
+			wantMatch: []int{0, 8, 15},
+		},
+		{
+			name: "only empty slots match",
+			ctrl: func() [16]byte {
+				c := fillCtrl(0b10000000)
+				c[5] = ctrlEmpty
+				c[11] = ctrlEmpty
+				return c
+			}(),
+			wantMatch: []int{5, 11},
+		},
+		{
+			name: "various non-full values in low range all match",
+			ctrl: func() [16]byte {
+				c := fillCtrl(0b10000000)
+				c[0] = 0b00000000 // empty
+				c[3] = 0b00000001 // low bit set, high bit clear -> matches
+				c[6] = 0b01111110 // high bit clear -> matches
+				c[9] = 0b01111111 // deleted
+				return c
+			}(),
+			wantMatch: []int{0, 3, 6, 9},
+		},
+		{
+			name: "full slots with different h2 values never match",
+			ctrl: [16]byte{
+				0b10000000, 0b10000001, 0b10010000, 0b10100000,
+				0b10110000, 0b11000000, 0b11010000, 0b11100000,
+				0b11110000, 0b11111111, 0b10000101, 0b10010010,
+				0b10101010, 0b10111011, 0b11001100, 0b11011101,
+			},
+			// all have high bit set
+			wantMatch: nil,
+		},
+		{
+			name: "alternating empty/deleted and full",
+			ctrl: func() [16]byte {
+				var c [16]byte
+				for i := range c {
+					switch i % 3 {
+					case 0:
+						c[i] = ctrlEmpty
+					case 1:
+						c[i] = ctrlDeleted
+					case 2:
+						c[i] = 0b10000101
+					}
+				}
+				return c
+			}(),
+			wantMatch: []int{0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchEmptyOrDeleted(tc.ctrl[:])
+			require.Equal(t, maskFrom(tc.wantMatch), got)
+		})
+	}
+}
+
+func TestSwissPositionMapBasic(t *testing.T) {
+	tests := []struct {
+		name       string
+		numEntries int
+		capacity   uint64
+	}{
+		{"low collision", 3, 100},
+		{"high collision", 60, 20}, // small capacity forces linear probing
+		{"large low collision", 10000, 20000},
+		{"large high collision", 10000, 100}, // extreme overload forces many resizes
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, hashes := newTestSwissMap(t, tt.numEntries, tt.capacity)
+
+			// Insert all entries.
+			for i, h := range hashes {
+				require.NoError(t, m.Set(h, packPosIndex(uint64(i), 0)))
+			}
+			require.Equal(t, uint64(tt.numEntries), m.Count())
+
+			// Get them back.
+			for i, h := range hashes {
+				packed, ok, err := m.Get(h)
+				require.NoError(t, err)
+				require.True(t, ok, "entry %d should exist", i)
+				require.Equal(t, packPosIndex(uint64(i), 0), packed)
+			}
+
+			// Non-existent key.
+			_, ok, err := m.Get(testHashFromInt(tt.numEntries + 1))
+			require.NoError(t, err)
+			require.False(t, ok)
+
+			// Delete even-indexed entries to create tombstones.
+			for i := 0; i < tt.numEntries; i += 2 {
+				ok, err := m.Delete(hashes[i])
+				require.NoError(t, err, "delete entry %d", i)
+				require.True(t, ok, "delete entry %d", i)
+			}
+			surviving := uint64(tt.numEntries / 2)
+			require.Equal(t, surviving, m.Count())
+
+			// Deleted entries should not be found.
+			for i := 0; i < tt.numEntries; i += 2 {
+				_, ok, err := m.Get(hashes[i])
+				require.NoError(t, err, "entry %d", i)
+				require.False(t, ok, "deleted entry %d should not be found", i)
+			}
+
+			// Surviving entries should still exist.
+			for i := 1; i < tt.numEntries; i += 2 {
+				_, ok, err := m.Get(hashes[i])
+				require.NoError(t, err, "entry %d", i)
+				require.True(t, ok, "entry %d should still exist", i)
+			}
+
+			// Re-Set surviving entries with a different packed value.
+			// Verifies Set updates in-place rather than inserting
+			// duplicates when tombstones exist.
+			for i := 1; i < tt.numEntries; i += 2 {
+				require.NoError(t, m.Set(hashes[i], packPosIndex(uint64(i), 1)))
+			}
+			require.Equal(t, surviving, m.Count(),
+				"count should not change when updating existing entries")
+
+			// ForEach count must agree with Count().
+			var forEachCount uint64
+			m.ForEach(func(packed uint64) { forEachCount++ })
+			require.Equal(t, surviving, forEachCount,
+				"ForEach entry count must match Count()")
+
+			// Every surviving entry should return the updated packed value.
+			for i := 1; i < tt.numEntries; i += 2 {
+				packed, ok, err := m.Get(hashes[i])
+				require.NoError(t, err, "entry %d", i)
+				require.True(t, ok, "entry %d should still exist", i)
+				require.Equal(t, packPosIndex(uint64(i), 1), packed,
+					"entry %d should have the updated packed value", i)
+			}
+		})
+	}
+}
+
+// newTestSwissMap creates a SwissPositionMap backed by temp files with the
+// given number of test hashes written to the data file.
+func newTestSwissMap(t *testing.T, numEntries int, capacity uint64) (*SwissPositionMap, [][32]byte) {
+	t.Helper()
+
+	dataFile, err := os.Create(t.TempDir() + "/data")
+	require.NoError(t, err)
+	t.Cleanup(func() { dataFile.Close() })
+
+	hashes := make([][32]byte, numEntries)
+	for i := range numEntries {
+		hashes[i] = testHashFromInt(i)
+		_, err := dataFile.Write(hashes[i][:])
+		require.NoError(t, err)
+	}
+	dataFile.Seek(0, 0)
+
+	m, _, err := NewSwissPositionMap(
+		t.TempDir()+"/ctrl", t.TempDir()+"/slots",
+		capacity, [32]byte{}, dataFile, testPositionMask,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Close() })
+
+	return m, hashes
+}
+
+func TestSwissPositionMapConsistency(t *testing.T) {
+	hashes := [][32]byte{testHashFromInt(1), testHashFromInt(2), testHashFromInt(3)}
+	savedHash := [32]byte{1, 2, 3}
+
+	// buildTable creates a valid table with 3 entries and savedHash,
+	// then closes everything so the caller can corrupt files before reopening.
+	buildTable := func(t *testing.T, ctrlPath, slotsPath, dataPath string) {
+		t.Helper()
+		dataFile, err := os.Create(dataPath)
+		require.NoError(t, err)
+		for _, h := range hashes {
+			dataFile.Write(h[:])
+		}
+		dataFile.Seek(0, 0)
+
+		m, _, err := NewSwissPositionMap(ctrlPath, slotsPath, 100, [32]byte{}, dataFile, testPositionMask)
+		require.NoError(t, err)
+		for i, h := range hashes {
+			require.NoError(t, m.Set(h, uint64(i)))
+		}
+		require.NoError(t, m.SetConsistencyHash(savedHash))
+		m.Close()
+		dataFile.Close()
+	}
+
+	tests := []struct {
+		name            string
+		corrupt         func(t *testing.T, ctrlPath, slotsPath string) // nil = no corruption
+		reopenHash      [32]byte
+		expectedEntries uint64 // passed to NewSwissPositionMap on reopen
+		wantRebuild     bool
+		wantCount       uint64
+	}{
+		{
+			name:            "same hash, no corruption",
+			reopenHash:      savedHash,
+			expectedEntries: 100,
+			wantRebuild:     false,
+			wantCount:       3,
+		},
+		{
+			name:            "zero hash",
+			reopenHash:      [32]byte{},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:            "different hash",
+			reopenHash:      [32]byte{9, 9, 9},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:       "ctrl file truncated",
+			reopenHash: savedHash,
+			corrupt: func(t *testing.T, ctrlPath, _ string) {
+				require.NoError(t, os.Truncate(ctrlPath, 0))
+			},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:       "slots file truncated",
+			reopenHash: savedHash,
+			corrupt: func(t *testing.T, _, slotsPath string) {
+				require.NoError(t, os.Truncate(slotsPath, 0))
+			},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:       "ctrl header corrupted",
+			reopenHash: savedHash,
+			corrupt: func(t *testing.T, ctrlPath, _ string) {
+				f, err := os.OpenFile(ctrlPath, os.O_WRONLY, 0644)
+				require.NoError(t, err)
+				_, err = f.WriteAt([]byte{0xFF, 0xFE, 0xFD}, 0)
+				require.NoError(t, err)
+				f.Close()
+			},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:       "slots header corrupted",
+			reopenHash: savedHash,
+			corrupt: func(t *testing.T, _, slotsPath string) {
+				f, err := os.OpenFile(slotsPath, os.O_WRONLY, 0644)
+				require.NoError(t, err)
+				_, err = f.WriteAt([]byte{0xFF, 0xFE, 0xFD}, 0)
+				require.NoError(t, err)
+				f.Close()
+			},
+			expectedEntries: 100,
+			wantRebuild:     true,
+		},
+		{
+			name:            "different expectedEntries changes file size",
+			reopenHash:      savedHash,
+			expectedEntries: 200,
+			wantRebuild:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			ctrlPath := tmpDir + "/ctrl"
+			slotsPath := tmpDir + "/slots"
+			dataPath := tmpDir + "/data"
+			buildTable(t, ctrlPath, slotsPath, dataPath)
+
+			if tc.corrupt != nil {
+				tc.corrupt(t, ctrlPath, slotsPath)
+			}
+
+			dataFile, err := os.Open(dataPath)
+			require.NoError(t, err)
+			defer dataFile.Close()
+
+			m, needsRebuild, err := NewSwissPositionMap(ctrlPath, slotsPath, tc.expectedEntries, tc.reopenHash, dataFile, testPositionMask)
+			require.NoError(t, err)
+			defer m.Close()
+
+			require.Equal(t, tc.wantRebuild, needsRebuild)
+			require.Equal(t, tc.wantCount, m.Count())
+		})
+	}
+}
+
+func TestSwissPositionMapNilDataFile(t *testing.T) {
+	_, _, err := NewSwissPositionMap(t.TempDir()+"/ctrl", t.TempDir()+"/slots", 10, [32]byte{}, nil, testPositionMask)
+	require.Error(t, err)
+}
+
+// TestSwissPositionMapResizeConsistencyHash verifies that SetConsistencyHash
+// works after resize (i.e. ctrlMmap is updated, not stale).
+func TestSwissPositionMapResizeConsistencyHash(t *testing.T) {
+	m, hashes := newTestSwissMap(t, 100, 10)
+
+	initialSlots := m.numSlots
+
+	for i, h := range hashes {
+		require.NoError(t, m.Set(h, uint64(i)))
+	}
+	require.Greater(t, m.numSlots, initialSlots, "should have resized")
+
+	// SetConsistencyHash after resize must not panic and must not error.
+	var setErr error
+	require.NotPanics(t, func() {
+		setErr = m.SetConsistencyHash([32]byte{0xAB})
+	})
+	require.NoError(t, setErr)
+
+	// Verify the hash was actually written into the mmap.
+	var stored [32]byte
+	copy(stored[:], m.ctrlMmap[:32])
+	expected := [32]byte{0xAB}
+	require.Equal(t, expected, stored, "consistency hash should be readable from ctrlMmap after resize")
+}
+
+// TestSwissPositionMapConcurrentGet verifies that concurrent
+// Get calls are safe.
+func TestSwissPositionMapConcurrentGet(t *testing.T) {
+	// Find two hashes that land in different Swiss table buckets so
+	// concurrent Get calls exercise independent lookup paths.
+	hashA := testHashFromInt(1)
+	hashB := testHashFromInt(2)
+	for i := 3; ; i++ {
+		_, h2a := splitHash(hashA)
+		_, h2b := splitHash(hashB)
+		if h2a != h2b {
+			break
+		}
+		hashB = testHashFromInt(i)
+	}
+
+	posA := uint64(1)
+	posB := uint64(3)
+	dataSlots := uint64(4)
+
+	// Create a data file with hashes at the packed positions used below.
+	// Set(hashA, posA) reads from offset posA*32, Set(hashB, posB) reads from offset posB*32.
+	dataPath := t.TempDir() + "/data"
+	dataFile, err := os.Create(dataPath)
+	require.NoError(t, err)
+	defer dataFile.Close()
+
+	hashes := make([][32]byte, dataSlots)
+	hashes[posA] = hashA
+	hashes[posB] = hashB
+	for _, h := range hashes {
+		_, err := dataFile.Write(h[:])
+		require.NoError(t, err)
+	}
+
+	m, _, err := NewSwissPositionMap(t.TempDir()+"/ctrl", t.TempDir()+"/slots", dataSlots, [32]byte{}, dataFile, testPositionMask)
+	require.NoError(t, err)
+	defer m.Close()
+
+	require.NoError(t, m.Set(hashA, posA))
+	require.NoError(t, m.Set(hashB, posB))
+
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+	errs := make(chan error, 2)
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			gotHashA, found, err := m.Get(hashA)
+			if err != nil {
+				errs <- fmt.Errorf("Get(hashA): %w", err)
+				return
+			}
+			if !found || gotHashA != posA {
+				errs <- fmt.Errorf("expected %v, got found=%v hashA=%x", posA, found, gotHashA)
+				return
+			}
+
+			gotHashB, found, err := m.Get(hashB)
+			if err != nil {
+				errs <- fmt.Errorf("Get(hashB): %w", err)
+				return
+			}
+			if !found || gotHashB != posB {
+				errs <- fmt.Errorf("expected %v, got found=%v hashB=%x", posB, found, gotHashB)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for range 1000 {
+			gotHashB, found, err := m.Get(hashB)
+			if err != nil {
+				errs <- fmt.Errorf("Get(hashB): %w", err)
+				return
+			}
+			if !found || gotHashB != posB {
+				errs <- fmt.Errorf("expected %v, got found=%v hashB=%x", posB, found, gotHashB)
+				return
+			}
+
+			gotHashA, found, err := m.Get(hashA)
+			if err != nil {
+				errs <- fmt.Errorf("Get(hashA): %w", err)
+				return
+			}
+			if !found || gotHashA != posA {
+				errs <- fmt.Errorf("expected %v, got found=%v hashA=%x", posA, found, gotHashA)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func BenchmarkMatchH2(b *testing.B) {
+	ctrl := make([]byte, 16)
+	for i := range ctrl {
+		ctrl[i] = byte(i) | 0x80
+	}
+	ctrl[7] = 0x85
+
+	b.ResetTimer()
+	for b.Loop() {
+		matchH2(ctrl, 0x85)
+	}
+}
+
+func BenchmarkSwissGet(b *testing.B) {
+	tmpDir := b.TempDir()
+	dataPath := tmpDir + "/data"
+
+	// Create data file with 10k hashes
+	dataFile, _ := os.Create(dataPath)
+	numEntries := 10000
+	hashes := make([][32]byte, numEntries)
+	for i := range numEntries {
+		hashes[i] = testHashFromInt(i)
+		dataFile.Write(hashes[i][:])
+	}
+	dataFile.Seek(0, 0)
+
+	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, dataFile, testPositionMask)
+	defer m.Close()
+
+	for i, h := range hashes {
+		m.Set(h, uint64(i))
+	}
+
+	b.ResetTimer()
+	for i := range b.N {
+		m.Get(hashes[i%numEntries])
+	}
+}
+
+func BenchmarkSwissSet(b *testing.B) {
+	tmpDir := b.TempDir()
+	dataPath := tmpDir + "/data"
+
+	dataFile, _ := os.Create(dataPath)
+	numEntries := b.N
+	if numEntries > 100000 {
+		numEntries = 100000
+	}
+
+	hashes := make([][32]byte, numEntries)
+	for i := range numEntries {
+		hashes[i] = testHashFromInt(i)
+		dataFile.Write(hashes[i][:])
+	}
+	dataFile.Seek(0, 0)
+
+	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, dataFile, testPositionMask)
+	defer m.Close()
+
+	b.ResetTimer()
+	for i := range b.N {
+		m.Set(hashes[i%numEntries], uint64(i%numEntries))
+	}
+}
+
+// BenchmarkGoMapGet benchmarks native Go map for comparison.
+func BenchmarkGoMapGet(b *testing.B) {
+	type miniHash [12]byte
+
+	numEntries := 10000
+	hashes := make([]miniHash, numEntries)
+	m := make(map[miniHash]uint64, numEntries)
+
+	for i := range numEntries {
+		h := testHashFromInt(i)
+		copy(hashes[i][:], h[:12])
+		m[hashes[i]] = uint64(i)
+	}
+
+	b.ResetTimer()
+	for i := range b.N {
+		_ = m[hashes[i%numEntries]]
+	}
+}
+
+// BenchmarkGoMapSet benchmarks native Go map for comparison.
+func BenchmarkGoMapSet(b *testing.B) {
+	type miniHash [12]byte
+
+	numEntries := 10000
+	hashes := make([]miniHash, numEntries)
+	m := make(map[miniHash]uint64, numEntries)
+
+	for i := range numEntries {
+		h := testHashFromInt(i)
+		copy(hashes[i][:], h[:12])
+	}
+
+	b.ResetTimer()
+	for i := range b.N {
+		m[hashes[i%numEntries]] = uint64(i % numEntries)
+	}
+}


### PR DESCRIPTION
The positionMap lived in memory and was an additional source of memory usage.
To avoid this, we introduce a hash to position mapping that lives on disk and is mapped to memory via mmap.

The mapping algorithm is based on swiss tables and the key values (hashes) are shared with the ones from the forest data file. We check for eligible slots and then verify these eligible slots with the forest data file. The control word and slot data lives on disk but is memory mapped.