### PR TITLE
forest: Add ExpectedMaxLeaves option to presize the position map

### DIFF
--- a/forest.go
+++ b/forest.go
@@ -285,7 +285,7 @@ func readBlockCounts(file io.ReadSeeker) ([]uint32, error) {
 // load it with loadDeletedBitmap.
 // posMapCtrlPath and posMapSlotsPath are file paths for the Swiss Table position map.
 // forestRows sets the maximum tree height (determines max leaves = 2^forestRows).
-func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *deletedBitmap, posMapCtrlPath, posMapSlotsPath string, forestRows uint8) (*Forest, error) {
+func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *deletedBitmap, posMapCtrlPath, posMapSlotsPath string, forestRows uint8, expectedMaxLeaves uint64) (*Forest, error) {
 	if file == nil || blockCountsFile == nil || metaFile == nil {
 		return nil, fmt.Errorf("one of the given files are nil")
 	}
@@ -330,9 +330,15 @@ func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *de
 	metaFile.Seek(bestHashOffset, io.SeekStart)
 	metaFile.Read(consistencyHash[:])
 
-	// Create Swiss Table for position map. Size based on numLeaves (will resize if needed).
-	// Use a minimum of 1<<16 to avoid excessive early resizes on a fresh database.
-	expectedEntries := max(f.NumLeaves, 1<<16)
+	// Create Swiss Table for position map. Size based on numLeaves or
+	// expectedMaxLeaves (whichever is larger) to avoid costly resizes.
+	// When no hint is provided, use a minimum of 1<<16 to avoid excessive
+	// early resizes on a fresh database. Cap at 1<<33 to prevent
+	// accidental multi-hundred-GB allocations.
+	expectedEntries := max(f.NumLeaves, min(expectedMaxLeaves, 1<<33))
+	if expectedMaxLeaves == 0 {
+		expectedEntries = max(expectedEntries, 1<<16)
+	}
 	posMap, needsRebuild, err := swisstable.NewSwissPositionMap(posMapCtrlPath, posMapSlotsPath, expectedEntries, consistencyHash, file, positionMask)
 	if err != nil {
 		return nil, fmt.Errorf("create position map: %w", err)
@@ -359,7 +365,8 @@ func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *de
 type ForestOption func(*forestOptions)
 
 type forestOptions struct {
-	maxCacheMemory int64
+	maxCacheMemory    int64
+	expectedMaxLeaves uint64
 }
 
 // MaxCacheMemory sets the total WAL cache memory budget in bytes.
@@ -368,6 +375,15 @@ type forestOptions struct {
 func MaxCacheMemory(bytes int64) ForestOption {
 	return func(o *forestOptions) {
 		o.maxCacheMemory = bytes
+	}
+}
+
+// ExpectedMaxLeaves sets the expected maximum number of leaves for presizing
+// the position map. This avoids costly resizes during initial sync. If zero
+// or not set, the position map is sized based on the current NumLeaves.
+func ExpectedMaxLeaves(n uint64) ForestOption {
+	return func(o *forestOptions) {
+		o.expectedMaxLeaves = n
 	}
 }
 
@@ -470,6 +486,7 @@ func OpenForest(dbpath string, opts ...ForestOption) (*Forest, error) {
 		wal.Bitmap(),
 		ctrlPath, slotsPath,
 		defaultForestRows,
+		o.expectedMaxLeaves,
 	)
 	if err != nil {
 		for _, c := range closers {

--- a/forest_test.go
+++ b/forest_test.go
@@ -138,7 +138,7 @@ func newTestForest(t *testing.T, forestRows uint8) *Forest {
 	forest, err := newForest(
 		newMemFile(), newMemFile(), newMemFile(), nil,
 		tmpDir+"/ctrl", tmpDir+"/slots",
-		forestRows,
+		forestRows, 0,
 	)
 	require.NoError(t, err)
 	return forest
@@ -426,7 +426,7 @@ func FuzzForestChain(f *testing.F) {
 
 		memFile := newMemFile()
 		tmpDir := t.TempDir()
-		forest, err := newForest(memFile, newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 16)
+		forest, err := newForest(memFile, newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 16, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -511,14 +511,14 @@ func FuzzForestRecord(f *testing.F) {
 
 		// Forest using normal Modify
 		tmpDir1 := t.TempDir()
-		modifyForest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir1+"/ctrl", tmpDir1+"/slots", 16)
+		modifyForest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir1+"/ctrl", tmpDir1+"/slots", 16, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Forest using Record + HashAll
 		tmpDir2 := t.TempDir()
-		recordForest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir2+"/ctrl", tmpDir2+"/slots", 16)
+		recordForest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir2+"/ctrl", tmpDir2+"/slots", 16, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -622,7 +622,7 @@ func FuzzTreeBuilding(f *testing.F) {
 
 		memFile := newMemFile()
 		tmpDir := t.TempDir()
-		forest, err := newForest(memFile, newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 17)
+		forest, err := newForest(memFile, newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 17, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -668,7 +668,7 @@ func TestForestNoFlushBeforeWAL(t *testing.T) {
 
 	// Create forest backed by the WAL.
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10, 0)
 	require.NoError(t, err)
 
 	// Reference pollard for correctness comparison.
@@ -723,7 +723,7 @@ func TestForestNoFlushBeforeWAL(t *testing.T) {
 	require.NoError(t, err)
 	forest2, err := newForest(
 		underlyingFile, underlyingBlockCountsFile, underlyingMetaFile, bitmap2,
-		tmpDir2+"/ctrl", tmpDir2+"/slots", 10,
+		tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, forest.GetRoots(), forest2.GetRoots(),
@@ -750,7 +750,7 @@ func TestForestCrashRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 16)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 16, 0)
 	require.NoError(t, err)
 
 	pollard := NewAccumulator()
@@ -789,7 +789,7 @@ func TestForestCrashRecovery(t *testing.T) {
 	require.NoError(t, err)
 	preRecoveryForest, err := newForest(
 		mainFile, blockCountsFile, metaFile, preRecoveryBitmap,
-		tmpDir2+"/ctrl", tmpDir2+"/slots", 16,
+		tmpDir2+"/ctrl", tmpDir2+"/slots", 16, 0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, block200Roots, preRecoveryForest.GetRoots(),
@@ -806,7 +806,7 @@ func TestForestCrashRecovery(t *testing.T) {
 	tmpDir3 := t.TempDir()
 	recoveredForest, err := newForest(
 		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(),
-		tmpDir3+"/ctrl", tmpDir3+"/slots", 16,
+		tmpDir3+"/ctrl", tmpDir3+"/slots", 16, 0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, block400Roots, recoveredForest.GetRoots(),
@@ -839,7 +839,7 @@ func TestForestCrashIncompleteJournal(t *testing.T) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 16)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 16, 0)
 	require.NoError(t, err)
 
 	pollard := NewAccumulator()
@@ -884,7 +884,7 @@ func TestForestCrashIncompleteJournal(t *testing.T) {
 	tmpDir2 := t.TempDir()
 	recoveredForest, err := newForest(
 		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(),
-		tmpDir2+"/ctrl", tmpDir2+"/slots", 16,
+		tmpDir2+"/ctrl", tmpDir2+"/slots", 16, 0,
 	)
 	require.NoError(t, err)
 	require.Equal(t, savedRoots, recoveredForest.GetRoots(),
@@ -1011,7 +1011,7 @@ func TestForestUndoAfterRebuild(t *testing.T) {
 	tmpDir1 := t.TempDir()
 	forest, err := newForest(
 		w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(),
-		tmpDir1+"/ctrl", tmpDir1+"/slots", 10,
+		tmpDir1+"/ctrl", tmpDir1+"/slots", 10, 0,
 	)
 	require.NoError(t, err)
 
@@ -1073,7 +1073,7 @@ func TestForestUndoAfterRebuild(t *testing.T) {
 	tmpDir2 := t.TempDir()
 	forest2, err := newForest(
 		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(),
-		tmpDir2+"/ctrl", tmpDir2+"/slots", 10,
+		tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0,
 	)
 	require.NoError(t, err)
 
@@ -1230,7 +1230,7 @@ func TestForestBlockCountsReconciliation(t *testing.T) {
 			tmpDir := t.TempDir()
 			forest, err := newForest(
 				mainFile, blockCountsFile, metaFile, nil,
-				tmpDir+"/ctrl", tmpDir+"/slots", 10,
+				tmpDir+"/ctrl", tmpDir+"/slots", 10, 0,
 			)
 			require.NoError(t, err)
 			require.Equal(t, tc.numLeaves, forest.NumLeaves)

--- a/internal/swisstable/swisstable_fallback.go
+++ b/internal/swisstable/swisstable_fallback.go
@@ -28,8 +28,11 @@ type SwissPositionMap struct {
 // On non-unix platforms this always returns needsRebuild=true since the
 // map is not persisted.
 func NewSwissPositionMap(ctrlPath, slotsPath string, expectedEntries uint64, consistencyHash [32]byte, dataFile io.ReaderAt, posMask uint64) (*SwissPositionMap, bool, error) {
+	// Cap the presize hint to avoid multi-GB allocation on platforms
+	// where this in-memory fallback is used. The map grows as needed.
+	hint := min(expectedEntries, 1<<16)
 	return &SwissPositionMap{
-		m:        make(map[miniHash]uint64, expectedEntries),
+		m:        make(map[miniHash]uint64, hint),
 		dataFile: dataFile,
 	}, true, nil
 }

--- a/mappollard_test.go
+++ b/mappollard_test.go
@@ -1059,7 +1059,7 @@ func FuzzMapPollardTTLs(f *testing.F) {
 		memFile := newMemFile()
 		blockCountsFile := newMemFile()
 		tmpDir := t.TempDir()
-		forest, err := newForest(memFile, blockCountsFile, newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 16)
+		forest, err := newForest(memFile, blockCountsFile, newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 16, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pollard_test.go
+++ b/pollard_test.go
@@ -183,7 +183,7 @@ func testUndo(t *testing.T, utreexo UtreexoTest) {
 			utreexo = &v
 		case *Forest:
 			tmpDir := t.TempDir()
-			f, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 6)
+			f, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 6, 0)
 			if err != nil {
 				t.Fatalf("newForest: %v", err)
 			}
@@ -507,7 +507,7 @@ func TestModify(t *testing.T) {
 	testModify(t, &mpFull)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 10)
+	forest, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 10, 0)
 	if err != nil {
 		t.Fatalf("newForest: %v", err)
 	}
@@ -900,7 +900,7 @@ func fuzzUndo(t *testing.T, p UtreexoTest, startLeaves uint8, modifyAdds uint8, 
 		p = &v
 	case *Forest:
 		tmpDir := t.TempDir()
-		v, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 20)
+		v, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 20, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1101,7 +1101,7 @@ func FuzzUndoChain(f *testing.F) {
 			fuzzUndoChain(t, &p, numBlocks, numAdds, duration, seed)
 		case 2:
 			tmpDir := t.TempDir()
-			p, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 17)
+			p, err := newForest(newMemFile(), newMemFile(), newMemFile(), nil, tmpDir+"/ctrl", tmpDir+"/slots", 17, 0)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/wal_test.go
+++ b/wal_test.go
@@ -583,7 +583,7 @@ func TestWALForestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10, 0)
 	require.NoError(t, err)
 
 	pollard := NewAccumulator()
@@ -619,7 +619,7 @@ func TestWALForestIntegration(t *testing.T) {
 	tmpDir2 := t.TempDir()
 	bitmap2, err := loadDeletedBitmap(delFile)
 	require.NoError(t, err)
-	forest2, err := newForest(mainFile, blockCountsFile, metaFile, bitmap2, tmpDir2+"/ctrl", tmpDir2+"/slots", 10)
+	forest2, err := newForest(mainFile, blockCountsFile, metaFile, bitmap2, tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0)
 	require.NoError(t, err)
 	require.Equal(t, forest.GetRoots(), forest2.GetRoots(),
 		"roots should match after restart from WAL-flushed data")
@@ -643,7 +643,7 @@ func TestWALForestRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10, 0)
 	require.NoError(t, err)
 
 	pollard := NewAccumulator()
@@ -693,7 +693,7 @@ func TestWALForestRecovery(t *testing.T) {
 	// Build forest from recovered underlying files.
 	tmpDir2 := t.TempDir()
 	forest2, err := newForest(
-		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(), tmpDir2+"/ctrl", tmpDir2+"/slots", 10,
+		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(), tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0,
 	)
 	require.NoError(t, err)
 
@@ -724,7 +724,7 @@ func TestWALCrashBeforeCommit(t *testing.T) {
 	require.NoError(t, err)
 
 	tmpDir := t.TempDir()
-	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10)
+	forest, err := newForest(w.Cached(0), w.Cached(1), w.Cached(2), w.Bitmap(), tmpDir+"/ctrl", tmpDir+"/slots", 10, 0)
 	require.NoError(t, err)
 
 	pollard := NewAccumulator()
@@ -766,7 +766,7 @@ func TestWALCrashBeforeCommit(t *testing.T) {
 	// Build forest from underlying files — should be at block 1 state.
 	tmpDir2 := t.TempDir()
 	forest2, err := newForest(
-		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(), tmpDir2+"/ctrl", tmpDir2+"/slots", 10,
+		w2.Cached(0), w2.Cached(1), w2.Cached(2), w2.Bitmap(), tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Allow callers to presize the Swiss Table position map via ExpectedMaxLeaves to avoid costly resizes during initial sync. The non-unix fallback caps the hint at 1<<20 to avoid multi-GB in-memory allocation.