### PR TITLE
forest, mmapfile, cached_rws: forest concurrent rw

### DIFF
--- a/cached_rws.go
+++ b/cached_rws.go
@@ -57,17 +57,13 @@ type cachedRWS struct {
 	baseSize   int64 // underlying file size at wrap time
 }
 
-// newCachedRWS creates a cachedRWS wrapping the given io.ReadWriteSeeker.
-// It seeks to the end of the underlying file to determine its current size,
-// which is needed for correct SeekEnd behavior (e.g. append patterns).
-// entrySize specifies the fixed record size (4, 8, or 32 bytes).
-// maxCacheBytes controls when overflowed() signals that a flush is needed.
-// If maxCacheBytes is 0, defaultMaxCacheMemory is used.
-func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes int64) (*cachedRWS, error) {
-	size, err := underlying.Seek(0, io.SeekEnd)
-	if err != nil {
-		return nil, err
-	}
+// newCachedRWS creates a cachedRWS wrapping the given forestFile.
+// initialSize is the underlying file's current byte size; the caller is
+// expected to know it (e.g. via Stat for *os.File or the size passed to
+// mmapfile.Open). entrySize specifies the fixed record size (4, 8, or 32
+// bytes). maxCacheBytes controls when overflowed() signals that a flush
+// is needed; if 0, defaultMaxCacheMemory is used.
+func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes, initialSize int64) (*cachedRWS, error) {
 	if maxCacheBytes <= 0 {
 		maxCacheBytes = defaultMaxCacheMemory
 	}
@@ -80,10 +76,16 @@ func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes int64) (*c
 	return &cachedRWS{
 		underlying: underlying,
 		cache:      cache,
-		pos:        size,
-		maxWritten: size,
-		baseSize:   size,
+		pos:        initialSize,
+		maxWritten: initialSize,
+		baseSize:   initialSize,
 	}, nil
+}
+
+// Size returns the cachedRWS's current logical size, including any cached
+// writes that haven't been flushed to the underlying file yet.
+func (c *cachedRWS) Size() int64 {
+	return c.maxWritten
 }
 
 // ReadAt reads len(p) bytes starting at byte offset off, checking the cache
@@ -200,13 +202,9 @@ func (c *cachedRWS) Flush() error {
 	}
 	c.cache.clear()
 
-	// Update baseSize so subsequent reads can reach the newly flushed data
-	// in the underlying file.
-	size, err := c.underlying.Seek(0, io.SeekEnd)
-	if err != nil {
-		return err
-	}
-	c.baseSize = size
+	// All cached writes have been applied to the underlying file, so the
+	// underlying's new size is exactly maxWritten.
+	c.baseSize = c.maxWritten
 	return nil
 }
 
@@ -227,18 +225,13 @@ func (c *cachedRWS) FlushNeeded() bool {
 	return c.cache.overflowed()
 }
 
-// resetAfterFlush clears the cache and updates baseSize/maxWritten to
-// reflect the current underlying file size. This should be called after
-// writes have been applied to the underlying file (e.g. by the WAL),
-// so that a subsequent Discard resets to the correct post-flush baseline.
+// resetAfterFlush clears the cache and updates baseSize to reflect the
+// current underlying file size. This should be called after writes have
+// been applied to the underlying file (e.g. by the WAL), so that a
+// subsequent Discard resets to the correct post-flush baseline.
 func (c *cachedRWS) resetAfterFlush() error {
 	c.cache.clear()
-	size, err := c.underlying.Seek(0, io.SeekEnd)
-	if err != nil {
-		return err
-	}
-	c.baseSize = size
-	c.maxWritten = size
+	c.baseSize = c.maxWritten
 	c.pos = 0
 	return nil
 }

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -144,11 +144,7 @@ func (c *cachedRWS) Read(p []byte) (int, error) {
 		return n, nil
 	}
 	// Fall through to underlying file.
-	_, err := c.underlying.Seek(c.pos, io.SeekStart)
-	if err != nil {
-		return 0, err
-	}
-	n, err := c.underlying.Read(p)
+	n, err := c.underlying.ReadAt(p, c.pos)
 	c.pos += int64(n)
 	return n, err
 }
@@ -194,13 +190,7 @@ func (c *cachedRWS) Flush() error {
 		if flushErr != nil {
 			return
 		}
-		_, err := c.underlying.Seek(offset, io.SeekStart)
-		if err != nil {
-			flushErr = err
-			return
-		}
-		_, err = c.underlying.Write(data)
-		if err != nil {
+		if _, err := c.underlying.WriteAt(data, offset); err != nil {
 			flushErr = err
 			return
 		}

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -52,9 +52,8 @@ type cacheStore interface {
 type cachedRWS struct {
 	underlying forestFile
 	cache      cacheStore
-	pos        int64 // current seek position
-	maxWritten int64 // highest byte offset written (for SeekEnd)
-	baseSize   int64 // underlying file size at wrap time
+	maxWritten int64 // highest byte offset ever written (logical file size)
+	baseSize   int64 // underlying file size at last flush
 }
 
 // newCachedRWS creates a cachedRWS wrapping the given forestFile.
@@ -76,7 +75,6 @@ func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes, initialSi
 	return &cachedRWS{
 		underlying: underlying,
 		cache:      cache,
-		pos:        initialSize,
 		maxWritten: initialSize,
 		baseSize:   initialSize,
 	}, nil
@@ -107,10 +105,9 @@ func (c *cachedRWS) ReadAt(p []byte, off int64) (int, error) {
 	return c.underlying.ReadAt(p, off)
 }
 
-// WriteAt writes p to the cache at byte offset off. Like Write, the data
-// length must match the cache's entry size; unlike Write, it does not
-// advance the seek position, making it safe for concurrent disjoint-offset
-// writes from multiple goroutines.
+// WriteAt writes p to the cache at byte offset off. The data length must
+// match the cache's entry size. Safe for concurrent disjoint-offset
+// writes from multiple goroutines (no shared seek position).
 func (c *cachedRWS) WriteAt(p []byte, off int64) (int, error) {
 	if len(p) != c.cache.entrySize() {
 		return 0, fmt.Errorf("expected %d bytes, got %d", c.cache.entrySize(), len(p))
@@ -123,66 +120,6 @@ func (c *cachedRWS) WriteAt(p []byte, off int64) (int, error) {
 		c.maxWritten = end
 	}
 	return len(p), nil
-}
-
-// Read returns data from the cache if present, otherwise reads from
-// the underlying file. Positions beyond the underlying file size
-// return zeros without touching the file.
-func (c *cachedRWS) Read(p []byte) (int, error) {
-	if cached, ok := c.cache.get(c.pos); ok {
-		n := copy(p, cached)
-		c.pos += int64(n)
-		return n, nil
-	}
-	// If the read is entirely beyond the underlying file, return zeros
-	// without touching it. This avoids extending an in-memory file (or
-	// hitting EOF on a real file) for positions that only exist in the cache.
-	if c.pos >= c.baseSize {
-		for i := range p {
-			p[i] = 0
-		}
-		n := len(p)
-		c.pos += int64(n)
-		return n, nil
-	}
-	// Fall through to underlying file.
-	n, err := c.underlying.ReadAt(p, c.pos)
-	c.pos += int64(n)
-	return n, err
-}
-
-// Write stores data in the cache at the current position. The data length
-// must match the cache's entry size (4, 8, or 32 bytes).
-func (c *cachedRWS) Write(p []byte) (int, error) {
-	if len(p) != c.cache.entrySize() {
-		return 0, fmt.Errorf("expected %d bytes, got %d", c.cache.entrySize(), len(p))
-	}
-	if err := c.cache.put(c.pos, p); err != nil {
-		return 0, err
-	}
-
-	n := len(p)
-	c.pos += int64(n)
-	if c.pos > c.maxWritten {
-		c.maxWritten = c.pos
-	}
-	return n, nil
-}
-
-// Seek sets the position for the next Read or Write. For SeekEnd,
-// the end is defined as maxWritten (the highest position written to).
-func (c *cachedRWS) Seek(offset int64, whence int) (int64, error) {
-	switch whence {
-	case io.SeekStart:
-		c.pos = offset
-	case io.SeekCurrent:
-		c.pos += offset
-	case io.SeekEnd:
-		c.pos = c.maxWritten + offset
-	default:
-		return 0, fmt.Errorf("cachedRWS: invalid whence %d", whence)
-	}
-	return c.pos, nil
 }
 
 // Flush writes all cached data to the underlying file and clears the cache.
@@ -212,7 +149,6 @@ func (c *cachedRWS) Flush() error {
 func (c *cachedRWS) Discard() {
 	c.cache.clear()
 	c.maxWritten = c.baseSize
-	c.pos = 0
 }
 
 // Close releases resources held by the cache (e.g. mmap regions).
@@ -232,6 +168,5 @@ func (c *cachedRWS) FlushNeeded() bool {
 func (c *cachedRWS) resetAfterFlush() error {
 	c.cache.clear()
 	c.baseSize = c.maxWritten
-	c.pos = 0
 	return nil
 }

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -86,8 +86,11 @@ func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes int64) (*c
 	}, nil
 }
 
-// ReadAt reads len(p) bytes starting at byte offset off.
-// It checks the cache first, then falls through to the underlying file.
+// ReadAt reads len(p) bytes starting at byte offset off, checking the cache
+// first and falling through to the underlying file on miss. Follows the
+// io.ReaderAt contract: short reads return (n, io.EOF), and reads entirely
+// past the underlying file size return (0, io.EOF). Callers that want
+// "unwritten position reads as zero" semantics must handle io.EOF themselves.
 func (c *cachedRWS) ReadAt(p []byte, off int64) (int, error) {
 	if cached, ok := c.cache.get(off); ok {
 		n := copy(p, cached)
@@ -100,6 +103,24 @@ func (c *cachedRWS) ReadAt(p []byte, off int64) (int, error) {
 		return 0, io.EOF
 	}
 	return c.underlying.ReadAt(p, off)
+}
+
+// WriteAt writes p to the cache at byte offset off. Like Write, the data
+// length must match the cache's entry size; unlike Write, it does not
+// advance the seek position, making it safe for concurrent disjoint-offset
+// writes from multiple goroutines.
+func (c *cachedRWS) WriteAt(p []byte, off int64) (int, error) {
+	if len(p) != c.cache.entrySize() {
+		return 0, fmt.Errorf("expected %d bytes, got %d", c.cache.entrySize(), len(p))
+	}
+	if err := c.cache.put(off, p); err != nil {
+		return 0, err
+	}
+	end := off + int64(len(p))
+	if end > c.maxWritten {
+		c.maxWritten = end
+	}
+	return len(p), nil
 }
 
 // Read returns data from the cache if present, otherwise reads from

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -39,8 +39,8 @@ type cacheStore interface {
 	close()
 }
 
-// cachedRWS wraps an io.ReadWriteSeeker, buffering all writes in memory.
-// Reads check the buffer first (exact offset match), then fall through to
+// cachedRWS wraps a forestFile, buffering all writes in memory. Reads
+// check the buffer first (exact offset match), then fall through to
 // the underlying file on miss. This enables atomic modifications: call
 // Flush to commit buffered writes, or Discard to throw them away.
 //

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -3,6 +3,7 @@ package utreexo
 import (
 	"fmt"
 	"io"
+	"sync/atomic"
 )
 
 const (
@@ -52,8 +53,8 @@ type cacheStore interface {
 type cachedRWS struct {
 	underlying forestFile
 	cache      cacheStore
-	maxWritten int64 // highest byte offset ever written (logical file size)
-	baseSize   int64 // underlying file size at last flush
+	maxWritten atomic.Int64 // highest byte offset ever written (logical file size)
+	baseSize   int64        // underlying file size at last flush
 }
 
 // newCachedRWS creates a cachedRWS wrapping the given forestFile.
@@ -72,18 +73,19 @@ func newCachedRWS(underlying forestFile, entrySize int, maxCacheBytes, initialSi
 		return nil, err
 	}
 
-	return &cachedRWS{
+	c := &cachedRWS{
 		underlying: underlying,
 		cache:      cache,
-		maxWritten: initialSize,
 		baseSize:   initialSize,
-	}, nil
+	}
+	c.maxWritten.Store(initialSize)
+	return c, nil
 }
 
 // Size returns the cachedRWS's current logical size, including any cached
 // writes that haven't been flushed to the underlying file yet.
 func (c *cachedRWS) Size() int64 {
-	return c.maxWritten
+	return c.maxWritten.Load()
 }
 
 // ReadAt reads len(p) bytes starting at byte offset off, checking the cache
@@ -116,8 +118,14 @@ func (c *cachedRWS) WriteAt(p []byte, off int64) (int, error) {
 		return 0, err
 	}
 	end := off + int64(len(p))
-	if end > c.maxWritten {
-		c.maxWritten = end
+	for {
+		old := c.maxWritten.Load()
+		if end <= old {
+			break
+		}
+		if c.maxWritten.CompareAndSwap(old, end) {
+			break
+		}
 	}
 	return len(p), nil
 }
@@ -141,14 +149,14 @@ func (c *cachedRWS) Flush() error {
 
 	// All cached writes have been applied to the underlying file, so the
 	// underlying's new size is exactly maxWritten.
-	c.baseSize = c.maxWritten
+	c.baseSize = c.maxWritten.Load()
 	return nil
 }
 
 // Discard drops all buffered writes without touching the underlying file.
 func (c *cachedRWS) Discard() {
 	c.cache.clear()
-	c.maxWritten = c.baseSize
+	c.maxWritten.Store(c.baseSize)
 }
 
 // Close releases resources held by the cache (e.g. mmap regions).
@@ -167,6 +175,6 @@ func (c *cachedRWS) FlushNeeded() bool {
 // subsequent Discard resets to the correct post-flush baseline.
 func (c *cachedRWS) resetAfterFlush() error {
 	c.cache.clear()
-	c.baseSize = c.maxWritten
+	c.baseSize = c.maxWritten.Load()
 	return nil
 }

--- a/cached_rws_test.go
+++ b/cached_rws_test.go
@@ -143,7 +143,7 @@ func TestCachedRWSDiscard(t *testing.T) {
 	require.Equal(t, 0, c.cache.count())
 
 	// maxWritten should be reset to baseSize.
-	require.Equal(t, c.baseSize, c.maxWritten)
+	require.Equal(t, c.baseSize, c.maxWritten.Load())
 
 	// Read from offset 0 should return the original hash (from underlying).
 	var got [32]byte

--- a/cached_rws_test.go
+++ b/cached_rws_test.go
@@ -2,7 +2,6 @@ package utreexo
 
 import (
 	"encoding/binary"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,77 +12,68 @@ func TestCachedRWSReadWrite(t *testing.T) {
 
 	// Pre-populate underlying with 32 bytes at offset 0.
 	hash := testHashFromInt(1)
-	_, err := underlying.Write(hash[:])
+	_, err := underlying.WriteAt(hash[:], 0)
 	require.NoError(t, err)
 
 	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Read from underlying (cache miss).
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
 	var got [32]byte
-	n, err := c.Read(got[:])
+	n, err := c.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 	require.Equal(t, hash, Hash(got))
 
 	// Write a new hash at offset 0 (only goes to cache).
 	newHash := testHashFromInt(2)
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	n, err = c.Write(newHash[:])
+	n, err = c.WriteAt(newHash[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 
 	// Read back from cache (should see new hash, not underlying).
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	n, err = c.Read(got[:])
+	n, err = c.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 	require.Equal(t, newHash, Hash(got))
 
 	// Underlying should still have the original hash.
-	_, err = underlying.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	n, err = underlying.Read(got[:])
+	n, err = underlying.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 	require.Equal(t, hash, Hash(got))
 }
 
-func TestCachedRWSSeekEndAppend(t *testing.T) {
-	// Simulate the deletedFile append pattern:
-	// Seek(0, SeekEnd) then Write(8 bytes), repeated.
+func TestCachedRWSAppend(t *testing.T) {
+	// Simulate the deletedFile append pattern: WriteAt at the current
+	// Size(), repeated.
 	underlying := newMemFile()
 
 	// Write an 8-byte header to underlying.
 	var header [8]byte
-	_, err := underlying.Write(header[:])
+	_, err := underlying.WriteAt(header[:], 0)
 	require.NoError(t, err)
 
 	c, err := newCachedRWS(underlying, 8, 0, underlying.Size())
 	require.NoError(t, err)
 
-	// Append three 8-byte entries via SeekEnd.
+	// Append three 8-byte entries.
 	for i := uint64(0); i < 3; i++ {
-		pos, err := c.Seek(0, io.SeekEnd)
-		require.NoError(t, err)
-		require.Equal(t, int64(8+i*8), pos, "append %d should be at correct offset", i)
+		off := c.Size()
+		require.Equal(t, int64(8+i*8), off, "append %d should be at correct offset", i)
 
-		err = binary.Write(c, binary.LittleEndian, i+100)
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], i+100)
+		_, err = c.WriteAt(buf[:], off)
 		require.NoError(t, err)
 	}
 
 	// Read them back from cache.
 	for i := uint64(0); i < 3; i++ {
-		_, err = c.Seek(int64(8+i*8), io.SeekStart)
+		var buf [8]byte
+		_, err = c.ReadAt(buf[:], int64(8+i*8))
 		require.NoError(t, err)
-		var val uint64
-		err = binary.Read(c, binary.LittleEndian, &val)
-		require.NoError(t, err)
-		require.Equal(t, i+100, val)
+		require.Equal(t, i+100, binary.LittleEndian.Uint64(buf[:]))
 	}
 }
 
@@ -97,13 +87,9 @@ func TestCachedRWSFlush(t *testing.T) {
 	h1 := testHashFromInt(10)
 	h2 := testHashFromInt(20)
 
-	_, err = c.Seek(0, io.SeekStart)
+	_, err = c.WriteAt(h1[:], 0)
 	require.NoError(t, err)
-	_, err = c.Write(h1[:])
-	require.NoError(t, err)
-	_, err = c.Seek(32, io.SeekStart)
-	require.NoError(t, err)
-	_, err = c.Write(h2[:])
+	_, err = c.WriteAt(h2[:], 32)
 	require.NoError(t, err)
 
 	// Underlying should be empty before flush.
@@ -117,13 +103,11 @@ func TestCachedRWSFlush(t *testing.T) {
 	require.Equal(t, 64, len(underlying.data))
 
 	var got [32]byte
-	_, err = underlying.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = underlying.Read(got[:])
+	_, err = underlying.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, h1, Hash(got))
 
-	_, err = underlying.Read(got[:])
+	_, err = underlying.ReadAt(got[:], 32)
 	require.NoError(t, err)
 	require.Equal(t, h2, Hash(got))
 
@@ -136,7 +120,7 @@ func TestCachedRWSDiscard(t *testing.T) {
 
 	// Pre-populate underlying.
 	origHash := testHashFromInt(42)
-	_, err := underlying.Write(origHash[:])
+	_, err := underlying.WriteAt(origHash[:], 0)
 	require.NoError(t, err)
 
 	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
@@ -144,15 +128,11 @@ func TestCachedRWSDiscard(t *testing.T) {
 
 	// Write a different hash at offset 0.
 	newHash := testHashFromInt(99)
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = c.Write(newHash[:])
+	_, err = c.WriteAt(newHash[:], 0)
 	require.NoError(t, err)
 
 	// Also write beyond the original file.
-	_, err = c.Seek(32, io.SeekStart)
-	require.NoError(t, err)
-	_, err = c.Write(newHash[:])
+	_, err = c.WriteAt(newHash[:], 32)
 	require.NoError(t, err)
 
 	// Discard.
@@ -165,10 +145,8 @@ func TestCachedRWSDiscard(t *testing.T) {
 	require.Equal(t, c.baseSize, c.maxWritten)
 
 	// Read from offset 0 should return the original hash (from underlying).
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
 	var got [32]byte
-	n, err := c.Read(got[:])
+	n, err := c.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 	require.Equal(t, origHash, Hash(got))
@@ -182,7 +160,7 @@ func TestCachedRWSReadAfterWrite(t *testing.T) {
 
 	// Pre-populate with a stale hash.
 	stale := testHashFromInt(1)
-	_, err := underlying.Write(stale[:])
+	_, err := underlying.WriteAt(stale[:], 0)
 	require.NoError(t, err)
 
 	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
@@ -190,16 +168,12 @@ func TestCachedRWSReadAfterWrite(t *testing.T) {
 
 	// Write a fresh hash at the same offset.
 	fresh := testHashFromInt(2)
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = c.Write(fresh[:])
+	_, err = c.WriteAt(fresh[:], 0)
 	require.NoError(t, err)
 
 	// Read at the same offset should return the fresh hash.
-	_, err = c.Seek(0, io.SeekStart)
-	require.NoError(t, err)
 	var got [32]byte
-	_, err = c.Read(got[:])
+	_, err = c.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, fresh, Hash(got))
 }

--- a/cached_rws_test.go
+++ b/cached_rws_test.go
@@ -16,7 +16,7 @@ func TestCachedRWSReadWrite(t *testing.T) {
 	_, err := underlying.Write(hash[:])
 	require.NoError(t, err)
 
-	c, err := newCachedRWS(underlying, 32, 0)
+	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Read from underlying (cache miss).
@@ -63,7 +63,7 @@ func TestCachedRWSSeekEndAppend(t *testing.T) {
 	_, err := underlying.Write(header[:])
 	require.NoError(t, err)
 
-	c, err := newCachedRWS(underlying, 8, 0)
+	c, err := newCachedRWS(underlying, 8, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Append three 8-byte entries via SeekEnd.
@@ -90,7 +90,7 @@ func TestCachedRWSSeekEndAppend(t *testing.T) {
 func TestCachedRWSFlush(t *testing.T) {
 	underlying := newMemFile()
 
-	c, err := newCachedRWS(underlying, 32, 0)
+	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Write two hashes at different offsets.
@@ -139,7 +139,7 @@ func TestCachedRWSDiscard(t *testing.T) {
 	_, err := underlying.Write(origHash[:])
 	require.NoError(t, err)
 
-	c, err := newCachedRWS(underlying, 32, 0)
+	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Write a different hash at offset 0.
@@ -185,7 +185,7 @@ func TestCachedRWSReadAfterWrite(t *testing.T) {
 	_, err := underlying.Write(stale[:])
 	require.NoError(t, err)
 
-	c, err := newCachedRWS(underlying, 32, 0)
+	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
 	require.NoError(t, err)
 
 	// Write a fresh hash at the same offset.

--- a/cached_rws_test.go
+++ b/cached_rws_test.go
@@ -2,6 +2,7 @@ package utreexo
 
 import (
 	"encoding/binary"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,4 +177,49 @@ func TestCachedRWSReadAfterWrite(t *testing.T) {
 	_, err = c.ReadAt(got[:], 0)
 	require.NoError(t, err)
 	require.Equal(t, fresh, Hash(got))
+}
+
+func TestCachedRWSConcurrentDisjointWrites(t *testing.T) {
+	underlying := newMemFile()
+
+	c, err := newCachedRWS(underlying, 32, 0, underlying.Size())
+	require.NoError(t, err)
+
+	const numWriters = 64
+	hashes := make([]Hash, numWriters)
+	for i := range hashes {
+		hashes[i] = testHashFromInt(i + 1)
+	}
+
+	// Release all goroutines simultaneously to maximize overlap.
+	// Each writer targets its own disjoint 32-byte slot and writes into
+	// its own slot in errs, so the slice itself is race-free.
+	start := make(chan struct{})
+	errs := make([]error, numWriters)
+	var wg sync.WaitGroup
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = c.WriteAt(hashes[i][:], int64(i)*32)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "writer %d", i)
+	}
+
+	// Every disjoint write should be readable from cache at its own offset.
+	for i := 0; i < numWriters; i++ {
+		var got [32]byte
+		n, err := c.ReadAt(got[:], int64(i)*32)
+		require.NoError(t, err)
+		require.Equal(t, 32, n)
+		require.Equalf(t, hashes[i], Hash(got), "offset %d", i*32)
+	}
+
+	require.Equal(t, int64(numWriters)*32, c.Size())
 }

--- a/forest.go
+++ b/forest.go
@@ -64,6 +64,25 @@ type forestFile interface {
 	io.WriterAt
 }
 
+// fileSize asks f for its current byte size, preferring an explicit
+// Size() int64 method (cachedRWS, mmapFile, memFile) and falling back
+// to Stat() (e.g. *os.File). This avoids wrapping *os.File just to
+// expose a Size method — callers that have one in hand can pass it
+// through directly.
+func fileSize(f any) (int64, error) {
+	if s, ok := f.(interface{ Size() int64 }); ok {
+		return s.Size(), nil
+	}
+	if s, ok := f.(interface{ Stat() (os.FileInfo, error) }); ok {
+		st, err := s.Stat()
+		if err != nil {
+			return 0, err
+		}
+		return st.Size(), nil
+	}
+	return 0, fmt.Errorf("fileSize: %T has no Size or Stat method", f)
+}
+
 // positionMap value packing: upper 17 bits = addIndex, lower 47 bits = position
 // Supports up to 2^47 (~140 trillion) leaves and 2^17 (131,072) adds per block.
 const (
@@ -151,12 +170,8 @@ func (b *deletedBitmap) clearDirty() {
 
 // loadDeletedBitmap reads a bitmap file into a new deletedBitmap.
 // The file stores uint64 words in little-endian format, one per 8 bytes.
-func loadDeletedBitmap(file io.ReadSeeker) (*deletedBitmap, error) {
-	size, err := file.Seek(0, io.SeekEnd)
-	if err != nil {
-		return nil, err
-	}
-
+// size is the bitmap file's current byte length.
+func loadDeletedBitmap(file io.ReaderAt, size int64) (*deletedBitmap, error) {
 	if size == 0 {
 		return newDeletedBitmap(0), nil
 	}
@@ -165,12 +180,8 @@ func loadDeletedBitmap(file io.ReadSeeker) (*deletedBitmap, error) {
 		return nil, fmt.Errorf("bitmap file size %d is not a multiple of 8", size)
 	}
 
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return nil, err
-	}
-
 	buf := make([]byte, size)
-	if _, err := io.ReadFull(file, buf); err != nil {
+	if _, err := file.ReadAt(buf, 0); err != nil && err != io.EOF {
 		return nil, err
 	}
 
@@ -249,23 +260,16 @@ type Forest struct {
 }
 
 // readBlockCounts reads all uint32 entries from a block counts file
-// and returns them as a slice.
-func readBlockCounts(file io.ReadSeeker) ([]uint32, error) {
-	size, err := file.Seek(0, io.SeekEnd)
-	if err != nil {
-		return nil, err
-	}
+// and returns them as a slice. size is the file's current byte length.
+func readBlockCounts(file io.ReaderAt, size int64) ([]uint32, error) {
 	if size == 0 {
 		return nil, nil
 	}
 	if size%4 != 0 {
 		return nil, fmt.Errorf("block counts file size %d is not a multiple of 4", size)
 	}
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return nil, err
-	}
 	buf := make([]byte, size)
-	if _, err := io.ReadFull(file.(io.Reader), buf); err != nil {
+	if _, err := file.ReadAt(buf, 0); err != nil && err != io.EOF {
 		return nil, err
 	}
 	n := size / 4
@@ -307,7 +311,11 @@ func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *de
 	// After undo-without-flush crashes, the block counts file may have
 	// stale entries at the end (one per undo). Remove entries from the
 	// end until the sum no longer exceeds numLeaves.
-	counts, err := readBlockCounts(blockCountsFile)
+	bcSize, err := fileSize(blockCountsFile)
+	if err != nil {
+		return nil, fmt.Errorf("blockCountsFile size: %w", err)
+	}
+	counts, err := readBlockCounts(blockCountsFile, bcSize)
 	if err != nil {
 		return nil, fmt.Errorf("read blockCountsFile: %w", err)
 	}
@@ -557,7 +565,11 @@ func (f *Forest) rebuildPositionMap() error {
 	}
 
 	// Load block counts from file into a local slice.
-	blockAdds, err := readBlockCounts(f.blockCountsFile)
+	bcSize, err := fileSize(f.blockCountsFile)
+	if err != nil {
+		return fmt.Errorf("blockCountsFile size: %w", err)
+	}
+	blockAdds, err := readBlockCounts(f.blockCountsFile, bcSize)
 	if err != nil {
 		return fmt.Errorf("read block counts: %w", err)
 	}
@@ -746,10 +758,14 @@ func (f *Forest) writeHash(position uint64, hash Hash) error {
 
 // appendBlockCount appends a block's add count to the block counts file.
 func (f *Forest) appendBlockCount(count uint32) error {
-	if _, err := f.blockCountsFile.Seek(0, io.SeekEnd); err != nil {
+	off, err := fileSize(f.blockCountsFile)
+	if err != nil {
 		return err
 	}
-	return binary.Write(f.blockCountsFile, binary.LittleEndian, count)
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], count)
+	_, err = f.blockCountsFile.WriteAt(buf[:], off)
+	return err
 }
 
 // add adds a single leaf to the forest.

--- a/forest.go
+++ b/forest.go
@@ -58,8 +58,9 @@ func dataFileSize(forestRows uint8) int64 {
 var _ Utreexo = (*Forest)(nil)
 
 // forestFile is the interface required for the main data file.
+// All I/O is positional; there is no shared seek position to coordinate
+// across goroutines.
 type forestFile interface {
-	io.ReadWriteSeeker
 	io.ReaderAt
 	io.WriterAt
 }
@@ -281,7 +282,8 @@ func readBlockCounts(file io.ReaderAt, size int64) ([]uint32, error) {
 }
 
 // newForest creates a new Forest backed by the given file.
-// The file should be an io.ReadWriteSeeker (e.g., *os.File).
+// The file must satisfy the forestFile interface (ReadAt + WriteAt);
+// *os.File satisfies it natively.
 // blockCountsFile stores the uint32 add-count per block; numLeaves is derived
 // from the cumulative sum of all block counts.
 // metaFile stores recordMode (bytes 0-31), numLeaves (bytes 32-63), and consistency hash (bytes 64-95).

--- a/forest.go
+++ b/forest.go
@@ -326,10 +326,11 @@ func newForest(file forestFile, blockCountsFile, metaFile forestFile, bitmap *de
 	}
 
 	// Read consistency hash from metaFile (bytes 64-95, written atomically by WAL).
-	// Zero hash on first run or if metaFile is empty.
+	// Zero hash on first run or if metaFile is empty (io.EOF leaves the buffer zeroed).
 	var consistencyHash [32]byte
-	metaFile.Seek(bestHashOffset, io.SeekStart)
-	metaFile.Read(consistencyHash[:])
+	if _, err := metaFile.ReadAt(consistencyHash[:], bestHashOffset); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("read consistency hash: %w", err)
+	}
 
 	// Create Swiss Table for position map. Size based on numLeaves or
 	// expectedMaxLeaves (whichever is larger) to avoid costly resizes.
@@ -578,16 +579,11 @@ func (f *Forest) rebuildPositionMap() error {
 	go func() {
 		defer close(hashCh)
 
-		if _, err := f.file.Seek(0, io.SeekStart); err != nil {
-			hashErrCh <- err
-			return
-		}
-
 		for pos := uint64(0); pos < f.NumLeaves; pos += batchSize {
 			n := min(uint64(batchSize), f.NumLeaves-pos)
 
 			buf := make([]byte, n*32)
-			if _, err := io.ReadFull(f.file, buf); err != nil {
+			if _, err := f.file.ReadAt(buf, f.posToFileOffset(pos)); err != nil {
 				hashErrCh <- err
 				return
 			}
@@ -637,12 +633,8 @@ func (f *Forest) rebuildPositionMap() error {
 // loadMetadata reads recordMode (bytes 0-31) and numLeaves (bytes 32-63)
 // from the metaFile. Each field occupies one 32-byte entry.
 func (f *Forest) loadMetadata() error {
-	_, err := f.metaFile.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
 	var buf [64]byte
-	_, err = f.metaFile.Read(buf[:])
+	_, err := f.metaFile.ReadAt(buf[:], 0)
 	if err == io.EOF {
 		// Fresh database, no metadata yet.
 		return nil
@@ -662,34 +654,29 @@ func (f *Forest) loadMetadata() error {
 // match the cachedRWS entry size. Both writes go through the WAL-protected
 // cachedRWS, so they are crash-safe.
 func (f *Forest) saveMetadata() error {
-	_, err := f.metaFile.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
-
 	var recordModeBuf [32]byte
 	if f.recordMode {
 		recordModeBuf[0] = 1
 	}
-	if _, err := f.metaFile.Write(recordModeBuf[:]); err != nil {
+	if _, err := f.metaFile.WriteAt(recordModeBuf[:], 0); err != nil {
 		return err
 	}
 
 	var numLeavesBuf [32]byte
 	binary.LittleEndian.PutUint64(numLeavesBuf[:], f.NumLeaves)
-	_, err = f.metaFile.Write(numLeavesBuf[:])
+	_, err := f.metaFile.WriteAt(numLeavesBuf[:], 32)
 	return err
 }
 
 // ReadConsistencyHash reads the consistency hash from metaFile (bytes 64-95).
-// The hash is written atomically by WAL.Flush().
+// The hash is written atomically by WAL.Flush(). Returns a zero hash on a
+// fresh database where the metaFile has not yet been written that far.
 func (f *Forest) ReadConsistencyHash() ([32]byte, error) {
 	var hash [32]byte
-	_, err := f.metaFile.Seek(bestHashOffset, io.SeekStart)
-	if err != nil {
-		return hash, err
+	_, err := f.metaFile.ReadAt(hash[:], bestHashOffset)
+	if err == io.EOF {
+		return hash, nil
 	}
-	_, err = io.ReadFull(f.metaFile, hash[:])
 	return hash, err
 }
 

--- a/forest.go
+++ b/forest.go
@@ -61,6 +61,7 @@ var _ Utreexo = (*Forest)(nil)
 type forestFile interface {
 	io.ReadWriteSeeker
 	io.ReaderAt
+	io.WriterAt
 }
 
 // positionMap value packing: upper 17 bits = addIndex, lower 47 bits = position
@@ -729,43 +730,31 @@ func (f *Forest) posToFileOffset(position uint64) int64 {
 	return rowBaseOffset(row, f.forestRows) + int64(position-rowStart)*32
 }
 
-// readHash reads the hash at the given position from the file.
+// readHash reads the hash at the given position from the file using ReadAt.
+// Positions that have never been written (read past EOF) yield a zero Hash,
+// matching the forest's "unwritten = empty" semantics.
+// Safe for concurrent use with other readHash/writeHash calls on disjoint
+// positions (no shared seek position).
 func (f *Forest) readHash(position uint64) (Hash, error) {
 	offset := f.posToFileOffset(position)
-	_, err := f.file.Seek(offset, io.SeekStart)
-	if err != nil {
-		return Hash{}, fmt.Errorf("seek to position %d: %w", position, err)
-	}
-
 	var hash Hash
-	n, err := f.file.Read(hash[:])
+	_, err := f.file.ReadAt(hash[:], offset)
+	if err == io.EOF {
+		return Hash{}, nil
+	}
 	if err != nil {
-		return Hash{}, fmt.Errorf("read at position %d: %w", position, err)
+		return Hash{}, err
 	}
-	if n != 32 {
-		return Hash{}, fmt.Errorf("short read at position %d: got %d bytes", position, n)
-	}
-
 	return hash, nil
 }
 
-// writeHash writes the hash at the given position to the file.
+// writeHash writes the hash at the given position to the file using WriteAt.
+// Safe for concurrent use with other readHash/writeHash calls on disjoint
+// positions (no shared seek position).
 func (f *Forest) writeHash(position uint64, hash Hash) error {
 	offset := f.posToFileOffset(position)
-	_, err := f.file.Seek(offset, io.SeekStart)
-	if err != nil {
-		return fmt.Errorf("seek to position %d: %w", position, err)
-	}
-
-	n, err := f.file.Write(hash[:])
-	if err != nil {
-		return fmt.Errorf("write at position %d: %w", position, err)
-	}
-	if n != 32 {
-		return fmt.Errorf("short write at position %d: wrote %d bytes", position, n)
-	}
-
-	return nil
+	_, err := f.file.WriteAt(hash[:], offset)
+	return err
 }
 
 // appendBlockCount appends a block's add count to the block counts file.

--- a/forest_test.go
+++ b/forest_test.go
@@ -91,6 +91,10 @@ func (m *memFile) WriteAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+func (m *memFile) Size() int64 {
+	return int64(len(m.data))
+}
+
 func (m *memFile) Truncate(size int64) error {
 	if size < int64(len(m.data)) {
 		m.data = m.data[:size]
@@ -733,7 +737,7 @@ func TestForestNoFlushBeforeWAL(t *testing.T) {
 
 	// Restart a new forest from the flushed underlying files.
 	tmpDir2 := t.TempDir()
-	bitmap2, err := loadDeletedBitmap(underlyingDelFile)
+	bitmap2, err := loadDeletedBitmap(underlyingDelFile, underlyingDelFile.Size())
 	require.NoError(t, err)
 	forest2, err := newForest(
 		underlyingFile, underlyingBlockCountsFile, underlyingMetaFile, bitmap2,
@@ -799,7 +803,7 @@ func TestForestCrashRecovery(t *testing.T) {
 
 	// Underlying files still only have block-200 data.
 	tmpDir2 := t.TempDir()
-	preRecoveryBitmap, err := loadDeletedBitmap(delFile)
+	preRecoveryBitmap, err := loadDeletedBitmap(delFile, delFile.Size())
 	require.NoError(t, err)
 	preRecoveryForest, err := newForest(
 		mainFile, blockCountsFile, metaFile, preRecoveryBitmap,
@@ -1250,7 +1254,7 @@ func TestForestBlockCountsReconciliation(t *testing.T) {
 			require.Equal(t, tc.numLeaves, forest.NumLeaves)
 
 			// Read back block counts and verify they were trimmed.
-			got, err := readBlockCounts(blockCountsFile)
+			got, err := readBlockCounts(blockCountsFile, blockCountsFile.Size())
 			require.NoError(t, err)
 
 			if tc.expectedCounts == nil {

--- a/forest_test.go
+++ b/forest_test.go
@@ -77,6 +77,20 @@ func (m *memFile) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+// WriteAt writes p at byte offset off, growing the backing slice with
+// zero bytes if off+len(p) extends past the current size. Does not
+// advance the seek position; safe alongside concurrent disjoint reads
+// (callers serialize their own writes — Truncate/extension is not
+// guarded against concurrent ReadAt).
+func (m *memFile) WriteAt(p []byte, off int64) (int, error) {
+	needed := off + int64(len(p)) - int64(len(m.data))
+	if needed > 0 {
+		m.data = append(m.data, make([]byte, needed)...)
+	}
+	n := copy(m.data[off:], p)
+	return n, nil
+}
+
 func (m *memFile) Truncate(size int64) error {
 	if size < int64(len(m.data)) {
 		m.data = m.data[:size]

--- a/internal/mmapfile/mmapfile.go
+++ b/internal/mmapfile/mmapfile.go
@@ -16,5 +16,6 @@ import (
 type File interface {
 	io.ReadWriteSeeker
 	io.ReaderAt
+	io.WriterAt
 	io.Closer
 }

--- a/internal/mmapfile/mmapfile.go
+++ b/internal/mmapfile/mmapfile.go
@@ -7,14 +7,13 @@ import (
 	"io"
 )
 
-// File is the interface returned by Open. It combines the read/write/seek
-// and random-read capabilities needed by the forest data file, plus
-// Close for resource cleanup.
+// File is the interface returned by Open. It provides positional
+// (ReaderAt/WriterAt) access to the forest data file, plus Close for
+// resource cleanup.
 //
 // Sync is discovered dynamically via type assertion by the WAL's
 // syncFile helper, so it is not part of this interface.
 type File interface {
-	io.ReadWriteSeeker
 	io.ReaderAt
 	io.WriterAt
 	io.Closer

--- a/internal/mmapfile/mmapfile_unix.go
+++ b/internal/mmapfile/mmapfile_unix.go
@@ -121,6 +121,11 @@ func (m *mmapFile) Seek(offset int64, whence int) (int64, error) {
 	return abs, nil
 }
 
+// Size returns the mapped region's size, fixed at Open time.
+func (m *mmapFile) Size() int64 {
+	return m.size
+}
+
 // Sync flushes the mapped pages to stable storage via fsync.
 func (m *mmapFile) Sync() error {
 	if m.data == nil {

--- a/internal/mmapfile/mmapfile_unix.go
+++ b/internal/mmapfile/mmapfile_unix.go
@@ -81,6 +81,24 @@ func (m *mmapFile) Write(p []byte) (int, error) {
 	return n, nil
 }
 
+// WriteAt writes p to the mapped region at byte offset off. Unlike Write
+// it does not advance the seek position, so concurrent calls at disjoint
+// offsets are safe. The mapping size is fixed at Open time; writes wholly
+// or partially past size return a short-write error.
+func (m *mmapFile) WriteAt(p []byte, off int64) (int, error) {
+	if m.data == nil {
+		return 0, errClosed
+	}
+	if off < 0 || off >= m.size {
+		return 0, fmt.Errorf("mmapFile: write at %d beyond size %d", off, m.size)
+	}
+	n := copy(m.data[off:m.size], p)
+	if n < len(p) {
+		return n, fmt.Errorf("mmapFile: short write at %d (wrote %d of %d)", off, n, len(p))
+	}
+	return n, nil
+}
+
 func (m *mmapFile) Seek(offset int64, whence int) (int64, error) {
 	if m.data == nil {
 		return 0, errClosed

--- a/internal/mmapfile/mmapfile_unix.go
+++ b/internal/mmapfile/mmapfile_unix.go
@@ -18,7 +18,6 @@ var errClosed = errors.New("mmapFile: use after close")
 type mmapFile struct {
 	data []byte   // mmap'd region; nil after Close
 	file *os.File // kept for Sync (fsync) and final close
-	pos  int64
 	size int64
 }
 
@@ -59,32 +58,9 @@ func (m *mmapFile) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
-func (m *mmapFile) Read(p []byte) (int, error) {
-	n, err := m.ReadAt(p, m.pos)
-	m.pos += int64(n)
-	return n, err
-}
-
-func (m *mmapFile) Write(p []byte) (int, error) {
-	if m.data == nil {
-		return 0, errClosed
-	}
-	start := m.pos
-	if start < 0 || start >= m.size {
-		return 0, fmt.Errorf("mmapFile: write at %d beyond size %d", start, m.size)
-	}
-	n := copy(m.data[start:m.size], p)
-	m.pos += int64(n)
-	if n < len(p) {
-		return n, fmt.Errorf("mmapFile: short write at %d (wrote %d of %d)", start, n, len(p))
-	}
-	return n, nil
-}
-
-// WriteAt writes p to the mapped region at byte offset off. Unlike Write
-// it does not advance the seek position, so concurrent calls at disjoint
-// offsets are safe. The mapping size is fixed at Open time; writes wholly
-// or partially past size return a short-write error.
+// WriteAt writes p to the mapped region at byte offset off. Concurrent
+// calls at disjoint offsets are safe. The mapping size is fixed at Open
+// time; writes wholly or partially past size return a short-write error.
 func (m *mmapFile) WriteAt(p []byte, off int64) (int, error) {
 	if m.data == nil {
 		return 0, errClosed
@@ -97,28 +73,6 @@ func (m *mmapFile) WriteAt(p []byte, off int64) (int, error) {
 		return n, fmt.Errorf("mmapFile: short write at %d (wrote %d of %d)", off, n, len(p))
 	}
 	return n, nil
-}
-
-func (m *mmapFile) Seek(offset int64, whence int) (int64, error) {
-	if m.data == nil {
-		return 0, errClosed
-	}
-	var abs int64
-	switch whence {
-	case io.SeekStart:
-		abs = offset
-	case io.SeekCurrent:
-		abs = m.pos + offset
-	case io.SeekEnd:
-		abs = m.size + offset
-	default:
-		return 0, fmt.Errorf("mmapFile: invalid whence %d", whence)
-	}
-	if abs < 0 {
-		return 0, fmt.Errorf("mmapFile: negative seek position %d", abs)
-	}
-	m.pos = abs
-	return abs, nil
 }
 
 // Size returns the mapped region's size, fixed at Open time.

--- a/wal.go
+++ b/wal.go
@@ -111,21 +111,30 @@ func newWAL(journal io.ReadWriteSeeker, bitmapFile forestFile, files ...walFile)
 		bitmapFile: bitmapFile,
 	}
 
-	// Replay any committed journal entries before creating caches,
-	// since newCachedRWS reads the underlying file size.
+	// Replay any committed journal entries before creating caches: each
+	// cachedRWS snapshots the underlying file's size at construction, so
+	// any recovery-time growth must already be reflected.
 	if err := w.recoverFromJournal(underlying); err != nil {
 		return nil, fmt.Errorf("wal recover: %w", err)
 	}
 
 	// Load bitmap from the (possibly recovered) underlying file.
-	bitmap, err := loadDeletedBitmap(w.bitmapFile)
+	bitmapSize, err := fileSize(w.bitmapFile)
+	if err != nil {
+		return nil, fmt.Errorf("wal bitmap size: %w", err)
+	}
+	bitmap, err := loadDeletedBitmap(w.bitmapFile, bitmapSize)
 	if err != nil {
 		return nil, fmt.Errorf("wal load bitmap: %w", err)
 	}
 	w.bitmap = bitmap
 
 	for i, f := range files {
-		c, err := newCachedRWS(f.File, f.EntrySize, f.MaxCacheBytes)
+		size, err := fileSize(f.File)
+		if err != nil {
+			return nil, fmt.Errorf("wal file %d size: %w", i, err)
+		}
+		c, err := newCachedRWS(f.File, f.EntrySize, f.MaxCacheBytes, size)
 		if err != nil {
 			return nil, fmt.Errorf("wal wrap file %d: %w", i, err)
 		}
@@ -336,7 +345,11 @@ func (w *wal) Discard() error {
 	// Reload bitmap from the underlying file to revert in-memory mutations.
 	// Unlike cachedRWS (which is a read-through cache over the underlying file),
 	// the bitmap is fully in-memory, so we must explicitly restore it.
-	bitmap, err := loadDeletedBitmap(w.bitmapFile)
+	bitmapSize, err := fileSize(w.bitmapFile)
+	if err != nil {
+		return fmt.Errorf("wal discard: bitmap size: %w", err)
+	}
+	bitmap, err := loadDeletedBitmap(w.bitmapFile, bitmapSize)
 	if err != nil {
 		return fmt.Errorf("wal discard: reload bitmap: %w", err)
 	}
@@ -389,11 +402,7 @@ func applyEntries(entries []journalEntry, underlying []forestFile) error {
 		if int(e.fileIdx) >= len(underlying) {
 			return fmt.Errorf("wal: fileIdx %d out of range (have %d files)", e.fileIdx, len(underlying))
 		}
-		f := underlying[e.fileIdx]
-		if _, err := f.Seek(e.offset, io.SeekStart); err != nil {
-			return err
-		}
-		if _, err := f.Write(e.data); err != nil {
+		if _, err := underlying[e.fileIdx].WriteAt(e.data, e.offset); err != nil {
 			return err
 		}
 	}

--- a/wal.go
+++ b/wal.go
@@ -522,7 +522,7 @@ func (w *wal) recoverFromJournal(underlying []forestFile) error {
 
 // syncFile calls Sync() on f if it supports it (e.g. *os.File).
 // For implementations without Sync (e.g. memFile), this is a no-op.
-func syncFile(f io.ReadWriteSeeker) error {
+func syncFile(f any) error {
 	if syncer, ok := f.(interface{ Sync() error }); ok {
 		return syncer.Sync()
 	}

--- a/wal.go
+++ b/wal.go
@@ -292,11 +292,7 @@ func (w *wal) applyFromCaches(bestHash [32]byte) error {
 			if applyErr != nil {
 				return
 			}
-			if _, err := c.underlying.Seek(offset, io.SeekStart); err != nil {
-				applyErr = fmt.Errorf("file %d seek to %d: %w", i, offset, err)
-				return
-			}
-			if _, err := c.underlying.Write(data); err != nil {
+			if _, err := c.underlying.WriteAt(data, offset); err != nil {
 				applyErr = fmt.Errorf("file %d write at %d: %w", i, offset, err)
 				return
 			}
@@ -312,11 +308,7 @@ func (w *wal) applyFromCaches(bestHash [32]byte) error {
 		if bitmapErr != nil {
 			return
 		}
-		if _, err := w.bitmapFile.Seek(offset, io.SeekStart); err != nil {
-			bitmapErr = fmt.Errorf("bitmap file seek to %d: %w", offset, err)
-			return
-		}
-		if _, err := w.bitmapFile.Write(data); err != nil {
+		if _, err := w.bitmapFile.WriteAt(data, offset); err != nil {
 			bitmapErr = fmt.Errorf("bitmap file write at %d: %w", offset, err)
 			return
 		}
@@ -327,10 +319,7 @@ func (w *wal) applyFromCaches(bestHash [32]byte) error {
 
 	// Write bestHash to metaFile at bestHashOffset.
 	metaFile := w.cached[metaFileIdx].underlying
-	if _, err := metaFile.Seek(bestHashOffset, io.SeekStart); err != nil {
-		return fmt.Errorf("metaFile seek: %w", err)
-	}
-	if _, err := metaFile.Write(bestHash[:]); err != nil {
+	if _, err := metaFile.WriteAt(bestHash[:], bestHashOffset); err != nil {
 		return fmt.Errorf("metaFile write bestHash: %w", err)
 	}
 

--- a/wal_test.go
+++ b/wal_test.go
@@ -617,7 +617,7 @@ func TestWALForestIntegration(t *testing.T) {
 
 	// Restart forest from flushed underlying files and verify roots match.
 	tmpDir2 := t.TempDir()
-	bitmap2, err := loadDeletedBitmap(delFile)
+	bitmap2, err := loadDeletedBitmap(delFile, delFile.Size())
 	require.NoError(t, err)
 	forest2, err := newForest(mainFile, blockCountsFile, metaFile, bitmap2, tmpDir2+"/ctrl", tmpDir2+"/slots", 10, 0)
 	require.NoError(t, err)

--- a/wal_test.go
+++ b/wal_test.go
@@ -125,18 +125,16 @@ func TestWALBasicFlush(t *testing.T) {
 
 	// Write a hash to file 0.
 	h := testHashFromInt(1)
-	_, err = w.Cached(0).Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = w.Cached(0).Write(h[:])
+	_, err = w.Cached(0).WriteAt(h[:], 0)
 	require.NoError(t, err)
 
 	// Mark a position as deleted in the bitmap (backed by files[0]).
 	w.Bitmap().set(42)
 
 	// Write 4 bytes to blockCounts (Cached(1)).
-	_, err = w.Cached(1).Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	err = binary.Write(w.Cached(1), binary.LittleEndian, int32(7))
+	var blockCountBuf [4]byte
+	binary.LittleEndian.PutUint32(blockCountBuf[:], 7)
+	_, err = w.Cached(1).WriteAt(blockCountBuf[:], 0)
 	require.NoError(t, err)
 
 	// Underlying files should still be empty.
@@ -477,9 +475,7 @@ func TestWALDiscard(t *testing.T) {
 
 	// Write data to cache.
 	h := testHashFromInt(1)
-	_, err = w.Cached(0).Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = w.Cached(0).Write(h[:])
+	_, err = w.Cached(0).WriteAt(h[:], 0)
 	require.NoError(t, err)
 
 	// Mutate bitmap.
@@ -519,9 +515,7 @@ func TestWALMultipleFlushes(t *testing.T) {
 
 	// First flush: write hash at offset 0.
 	h1 := testHashFromInt(1)
-	_, err = w.Cached(0).Seek(0, io.SeekStart)
-	require.NoError(t, err)
-	_, err = w.Cached(0).Write(h1[:])
+	_, err = w.Cached(0).WriteAt(h1[:], 0)
 	require.NoError(t, err)
 	require.NoError(t, w.Flush([32]byte{}))
 
@@ -529,9 +523,7 @@ func TestWALMultipleFlushes(t *testing.T) {
 
 	// Second flush: write hash at offset 32.
 	h2 := testHashFromInt(2)
-	_, err = w.Cached(0).Seek(32, io.SeekStart)
-	require.NoError(t, err)
-	_, err = w.Cached(0).Write(h2[:])
+	_, err = w.Cached(0).WriteAt(h2[:], 32)
 	require.NoError(t, err)
 	require.NoError(t, w.Flush([32]byte{}))
 
@@ -794,9 +786,7 @@ func TestWALFlushNeeded(t *testing.T) {
 	// Write enough entries to overflow the tiny cache.
 	for i := range 100 {
 		h := testHashFromInt(i)
-		_, err = w.Cached(0).Seek(int64(i)*32, io.SeekStart)
-		require.NoError(t, err)
-		_, err = w.Cached(0).Write(h[:])
+		_, err = w.Cached(0).WriteAt(h[:], int64(i)*32)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
We enable concurrent reads and writes for forest.