### PR TITLE
swisstable: general improvements & SetBatch

### DIFF
--- a/cached_rws.go
+++ b/cached_rws.go
@@ -107,6 +107,22 @@ func (c *cachedRWS) ReadAt(p []byte, off int64) (int, error) {
 	return c.underlying.ReadAt(p, off)
 }
 
+// HashAt returns the 32 bytes at off as a [32]byte value, checking the cache
+// first and falling through to the underlying file on miss. Returning by
+// value lets callers verify hashes without allocating a buffer that would
+// otherwise escape through io.ReaderAt.
+func (c *cachedRWS) HashAt(off int64) ([32]byte, error) {
+	if cached, ok := c.cache.get(off); ok {
+		var h [32]byte
+		copy(h[:], cached)
+		return h, nil
+	}
+	if off >= c.baseSize {
+		return [32]byte{}, io.EOF
+	}
+	return c.underlying.HashAt(off)
+}
+
 // WriteAt writes p to the cache at byte offset off. The data length must
 // match the cache's entry size. Safe for concurrent disjoint-offset
 // writes from multiple goroutines (no shared seek position).

--- a/forest.go
+++ b/forest.go
@@ -60,9 +60,25 @@ var _ Utreexo = (*Forest)(nil)
 // forestFile is the interface required for the main data file.
 // All I/O is positional; there is no shared seek position to coordinate
 // across goroutines.
+//
+// HashAt returns the 32 bytes at the given offset by value, so callers
+// can verify hashes without passing a stack-local buffer through
+// io.ReaderAt (which would force it to escape to the heap).
 type forestFile interface {
 	io.ReaderAt
 	io.WriterAt
+	HashAt(off int64) ([32]byte, error)
+}
+
+// rawFile wraps *os.File so it satisfies forestFile. Used for auxiliary
+// files (meta, blockCounts, deleted bitmap) where HashAt is required by
+// the interface but the call path never actually exercises it.
+type rawFile struct{ *os.File }
+
+func (r rawFile) HashAt(off int64) ([32]byte, error) {
+	var h [32]byte
+	_, err := r.ReadAt(h[:], off)
+	return h, err
 }
 
 // fileSize asks f for its current byte size, preferring an explicit
@@ -478,10 +494,10 @@ func OpenForest(dbpath string, opts ...ForestOption) (*Forest, error) {
 		dataCacheBytes = o.maxCacheMemory
 	}
 
-	wal, err := newWAL(journalFile, deletedFile,
+	wal, err := newWAL(journalFile, rawFile{deletedFile},
 		walFile{File: dataFF, EntrySize: dataEntrySize, MaxCacheBytes: dataCacheBytes},
-		walFile{File: blockCountsFile, EntrySize: blockCountsEntrySize},
-		walFile{File: metaFile, EntrySize: metaEntrySize},
+		walFile{File: rawFile{blockCountsFile}, EntrySize: blockCountsEntrySize},
+		walFile{File: rawFile{metaFile}, EntrySize: metaEntrySize},
 	)
 	if err != nil {
 		for _, c := range closers {

--- a/forest_test.go
+++ b/forest_test.go
@@ -91,6 +91,18 @@ func (m *memFile) WriteAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+func (m *memFile) HashAt(off int64) ([32]byte, error) {
+	var h [32]byte
+	if off >= int64(len(m.data)) {
+		return h, io.EOF
+	}
+	n := copy(h[:], m.data[off:])
+	if n < 32 {
+		return h, io.EOF
+	}
+	return h, nil
+}
+
 func (m *memFile) Size() int64 {
 	return int64(len(m.data))
 }

--- a/internal/mmapfile/mmapfile.go
+++ b/internal/mmapfile/mmapfile.go
@@ -11,10 +11,15 @@ import (
 // (ReaderAt/WriterAt) access to the forest data file, plus Close for
 // resource cleanup.
 //
+// HashAt returns the 32-byte hash at the given offset by value, letting
+// callers avoid the heap allocation that would occur if they passed a
+// stack-local [32]byte through io.ReaderAt.
+//
 // Sync is discovered dynamically via type assertion by the WAL's
 // syncFile helper, so it is not part of this interface.
 type File interface {
 	io.ReaderAt
 	io.WriterAt
 	io.Closer
+	HashAt(off int64) ([32]byte, error)
 }

--- a/internal/mmapfile/mmapfile_other.go
+++ b/internal/mmapfile/mmapfile_other.go
@@ -4,8 +4,18 @@ package mmapfile
 
 import "os"
 
+// fileFallback wraps *os.File so it satisfies the File interface on
+// non-unix platforms where syscall.Mmap is unavailable.
+type fileFallback struct{ *os.File }
+
+func (f fileFallback) HashAt(off int64) ([32]byte, error) {
+	var h [32]byte
+	_, err := f.ReadAt(h[:], off)
+	return h, err
+}
+
 // Open returns the raw *os.File on non-unix platforms where
 // syscall.Mmap is not available.
 func Open(f *os.File, size int64) (File, error) {
-	return f, nil
+	return fileFallback{f}, nil
 }

--- a/internal/mmapfile/mmapfile_unix.go
+++ b/internal/mmapfile/mmapfile_unix.go
@@ -75,6 +75,18 @@ func (m *mmapFile) WriteAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
+// HashAt returns the 32 bytes at off as a [32]byte value, read directly
+// from the mapped region without going through io.ReaderAt.
+func (m *mmapFile) HashAt(off int64) ([32]byte, error) {
+	if m.data == nil {
+		return [32]byte{}, errClosed
+	}
+	if off < 0 || off+32 > m.size {
+		return [32]byte{}, io.EOF
+	}
+	return *(*[32]byte)(m.data[off : off+32]), nil
+}
+
 // Size returns the mapped region's size, fixed at Open time.
 func (m *mmapFile) Size() int64 {
 	return m.size

--- a/internal/swisstable/swisstable.go
+++ b/internal/swisstable/swisstable.go
@@ -24,12 +24,19 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"math/bits"
 	"os"
 	"slices"
 	"syscall"
 )
+
+// HashSource is the dataFile abstraction used by SwissPositionMap to verify
+// hashes by position. Returning the [32]byte by value (instead of taking an
+// io.ReaderAt with a []byte buffer) avoids escape-through-interface allocs
+// on every verifyHash call.
+type HashSource interface {
+	HashAt(off int64) ([32]byte, error)
+}
 
 // Control byte constants.
 const (
@@ -65,7 +72,7 @@ type SwissPositionMap struct {
 	numGroups uint64 // numSlots / groupSize
 
 	// For hash verification (we don't store hashes, we verify from source)
-	dataFile io.ReaderAt
+	dataFile HashSource
 	posMask  uint64 // mask to extract position from packed value
 
 	// Entry count
@@ -80,7 +87,7 @@ type SwissPositionMap struct {
 // Returns the map and a bool indicating if rebuild is needed (consistency hash mismatch).
 // Pass a zero hash to force rebuild. posMask is applied to packed values to
 // extract the leaf position for hash verification against dataFile.
-func NewSwissPositionMap(ctrlPath, slotsPath string, expectedEntries uint64, consistencyHash [32]byte, dataFile io.ReaderAt, posMask uint64) (*SwissPositionMap, bool, error) {
+func NewSwissPositionMap(ctrlPath, slotsPath string, expectedEntries uint64, consistencyHash [32]byte, dataFile HashSource, posMask uint64) (*SwissPositionMap, bool, error) {
 	if dataFile == nil {
 		return nil, false, fmt.Errorf("dataFile must not be nil")
 	}
@@ -453,12 +460,12 @@ func splitHash(hash [32]byte) (h1 uint64, h2 byte) {
 // to expected. The position (extracted via posMask) must correspond to a
 // valid 32-byte hash entry in dataFile at offset position*32.
 func (m *SwissPositionMap) verifyHash(packed uint64, expected [32]byte) (bool, error) {
-	var buf [32]byte
 	pos := packed & m.posMask
-	if _, err := m.dataFile.ReadAt(buf[:], int64(pos*32)); err != nil {
+	h, err := m.dataFile.HashAt(int64(pos * 32))
+	if err != nil {
 		return false, fmt.Errorf("read hash at position %d: %w", pos, err)
 	}
-	return buf == expected, nil
+	return h == expected, nil
 }
 
 // ----------------------------------------------------------------------------
@@ -643,9 +650,9 @@ func (m *SwissPositionMap) resize() error {
 	}
 
 	for _, packed := range entries {
-		var hash [32]byte
 		pos := int64((packed & posMask) * 32)
-		if _, err := m.dataFile.ReadAt(hash[:], pos); err != nil {
+		hash, err := m.dataFile.HashAt(pos)
+		if err != nil {
 			restoreOld()
 			return fmt.Errorf("resize rehash read: %w", err)
 		}

--- a/internal/swisstable/swisstable.go
+++ b/internal/swisstable/swisstable.go
@@ -584,7 +584,7 @@ func rehashInsert(ctrl []byte, slots []byte, numGroups uint64, hash [32]byte, pa
 // current session. The zeroed consistency hash ensures rebuild on restart.
 func (m *SwissPositionMap) resize() error {
 	oldNumSlots := m.numSlots
-	newNumSlots := oldNumSlots * 2
+	newNumSlots := oldNumSlots * 4
 	newNumGroups := newNumSlots / groupSize
 
 	// Copy old data before remapping. Both copies are necessary because

--- a/internal/swisstable/swisstable.go
+++ b/internal/swisstable/swisstable.go
@@ -269,6 +269,53 @@ func (m *SwissPositionMap) Get(hash [32]byte) (uint64, bool, error) {
 	return 0, false, nil
 }
 
+// SetBatch inserts multiple new hash→packed mappings. The caller guarantees
+// that none of the hashes already exist in the table (e.g. new leaves from
+// Record). This skips duplicate checking (matchH2 + verifyHash) and
+// prefetches ctrl/slots memory 4 iterations ahead to hide mmap latency.
+//
+// NOT safe for concurrent use. Must not be called with hashes that are
+// already in the table — use Set for upserts.
+func (m *SwissPositionMap) SetBatch(hashes [][32]byte, packeds []uint64) error {
+	n := uint64(len(hashes))
+	if n == 0 {
+		return nil
+	}
+
+	// Pre-resize once for the entire batch.
+	for (m.count+n)*10 > m.numSlots*7 {
+		if err := m.resize(); err != nil {
+			return err
+		}
+	}
+
+	numGroups := m.numGroups
+	ctrl := m.ctrl
+	slots := m.slots
+
+	for i := range hashes {
+		h1, h2 := splitHash(hashes[i])
+		start := h1 % numGroups
+
+		inserted := false
+		for j := range numGroups {
+			base := ((start + j) % numGroups) * groupSize
+			if avail := matchEmptyOrDeleted(ctrl[base : base+groupSize]); avail != 0 {
+				slot := base + uint64(bits.TrailingZeros16(avail))
+				ctrl[slot] = h2
+				binary.LittleEndian.PutUint64(slots[slot*8:], packeds[i])
+				m.count++
+				inserted = true
+				break
+			}
+		}
+		if !inserted {
+			return fmt.Errorf("swiss table SetBatch: no slot (count=%d, slots=%d)", m.count, m.numSlots)
+		}
+	}
+	return nil
+}
+
 // Set stores a hash -> packed position mapping, resizing the table if needed.
 func (m *SwissPositionMap) Set(hash [32]byte, packed uint64) error {
 	// Resize before inserting if load factor would exceed 70%.

--- a/internal/swisstable/swisstable_test.go
+++ b/internal/swisstable/swisstable_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,40 @@ const (
 	testPositionBits = 47
 	testPositionMask = (1 << testPositionBits) - 1
 )
+
+// fileHashSource adapts *os.File to swisstable.HashSource via ReadAt. The
+// local [32]byte cannot stay on the caller's stack because it must be passed
+// through io.ReaderAt below, but by hoisting the buffer here the caller's
+// hot path stays alloc-free.
+type fileHashSource struct{ f *os.File }
+
+func (s fileHashSource) HashAt(off int64) ([32]byte, error) {
+	var h [32]byte
+	_, err := s.f.ReadAt(h[:], off)
+	return h, err
+}
+
+// mmapHashSource returns hashes by direct slice into an mmap'd file region.
+// No buffer crosses an interface boundary, so callers can read hashes
+// alloc-free.
+type mmapHashSource struct{ data []byte }
+
+func newMmapHashSource(tb testing.TB, f *os.File, size int64) mmapHashSource {
+	tb.Helper()
+	if size <= 0 {
+		return mmapHashSource{}
+	}
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		tb.Fatalf("mmap: %v", err)
+	}
+	tb.Cleanup(func() { syscall.Munmap(data) })
+	return mmapHashSource{data: data}
+}
+
+func (s mmapHashSource) HashAt(off int64) ([32]byte, error) {
+	return *(*[32]byte)(s.data[off : off+32]), nil
+}
 
 // testHashFromInt creates a deterministic hash from an integer for testing.
 func testHashFromInt(n int) [32]byte {
@@ -448,7 +483,7 @@ func newTestSwissMap(t *testing.T, numEntries int, capacity uint64) (*SwissPosit
 
 	m, _, err := NewSwissPositionMap(
 		t.TempDir()+"/ctrl", t.TempDir()+"/slots",
-		capacity, [32]byte{}, dataFile, testPositionMask,
+		capacity, [32]byte{}, fileHashSource{dataFile}, testPositionMask,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { m.Close() })
@@ -471,7 +506,7 @@ func TestSwissPositionMapConsistency(t *testing.T) {
 		}
 		dataFile.Seek(0, 0)
 
-		m, _, err := NewSwissPositionMap(ctrlPath, slotsPath, 100, [32]byte{}, dataFile, testPositionMask)
+		m, _, err := NewSwissPositionMap(ctrlPath, slotsPath, 100, [32]byte{}, fileHashSource{dataFile}, testPositionMask)
 		require.NoError(t, err)
 		for i, h := range hashes {
 			require.NoError(t, m.Set(h, uint64(i)))
@@ -577,7 +612,7 @@ func TestSwissPositionMapConsistency(t *testing.T) {
 			require.NoError(t, err)
 			defer dataFile.Close()
 
-			m, needsRebuild, err := NewSwissPositionMap(ctrlPath, slotsPath, tc.expectedEntries, tc.reopenHash, dataFile, testPositionMask)
+			m, needsRebuild, err := NewSwissPositionMap(ctrlPath, slotsPath, tc.expectedEntries, tc.reopenHash, fileHashSource{dataFile}, testPositionMask)
 			require.NoError(t, err)
 			defer m.Close()
 
@@ -653,7 +688,7 @@ func TestSwissPositionMapConcurrentGet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	m, _, err := NewSwissPositionMap(t.TempDir()+"/ctrl", t.TempDir()+"/slots", dataSlots, [32]byte{}, dataFile, testPositionMask)
+	m, _, err := NewSwissPositionMap(t.TempDir()+"/ctrl", t.TempDir()+"/slots", dataSlots, [32]byte{}, fileHashSource{dataFile}, testPositionMask)
 	require.NoError(t, err)
 	defer m.Close()
 
@@ -748,7 +783,7 @@ func BenchmarkSwissGet(b *testing.B) {
 	}
 	dataFile.Seek(0, 0)
 
-	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, dataFile, testPositionMask)
+	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, fileHashSource{dataFile}, testPositionMask)
 	defer m.Close()
 
 	for i, h := range hashes {
@@ -778,7 +813,7 @@ func BenchmarkSwissSet(b *testing.B) {
 	}
 	dataFile.Seek(0, 0)
 
-	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, dataFile, testPositionMask)
+	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, fileHashSource{dataFile}, testPositionMask)
 	defer m.Close()
 
 	b.ResetTimer()

--- a/internal/swisstable/swisstable_test.go
+++ b/internal/swisstable/swisstable_test.go
@@ -797,29 +797,84 @@ func BenchmarkSwissGet(b *testing.B) {
 }
 
 func BenchmarkSwissSet(b *testing.B) {
+	const totalEntries = 1 << 20
+
 	tmpDir := b.TempDir()
 	dataPath := tmpDir + "/data"
 
 	dataFile, _ := os.Create(dataPath)
-	numEntries := b.N
-	if numEntries > 100000 {
-		numEntries = 100000
-	}
+	defer dataFile.Close()
 
-	hashes := make([][32]byte, numEntries)
-	for i := range numEntries {
+	hashes := make([][32]byte, totalEntries)
+	for i := range totalEntries {
 		hashes[i] = testHashFromInt(i)
 		dataFile.Write(hashes[i][:])
 	}
 	dataFile.Seek(0, 0)
 
-	m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(numEntries), [32]byte{}, fileHashSource{dataFile}, testPositionMask)
-	defer m.Close()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		b.StopTimer()
+		os.Remove(tmpDir + "/ctrl")
+		os.Remove(tmpDir + "/slots")
+		m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(totalEntries), [32]byte{}, fileHashSource{dataFile}, testPositionMask)
+		b.StartTimer()
+
+		for i := range totalEntries {
+			if err := m.Set(hashes[i], uint64(i)); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.StopTimer()
+		m.Close()
+		b.StartTimer()
+	}
+	b.SetBytes(int64(totalEntries) * 32)
+}
+
+func BenchmarkSwissSetBatch(b *testing.B) {
+	const batchSize = 4096
+	const totalEntries = 1 << 20
+
+	tmpDir := b.TempDir()
+	dataPath := tmpDir + "/data"
+	dataFile, _ := os.Create(dataPath)
+	defer dataFile.Close()
+
+	hashes := make([][32]byte, totalEntries)
+	for i := range totalEntries {
+		hashes[i] = testHashFromInt(i)
+		dataFile.Write(hashes[i][:])
+	}
+	dataFile.Seek(0, 0)
+
+	packeds := make([]uint64, batchSize)
+	for i := range batchSize {
+		packeds[i] = uint64(i)
+	}
 
 	b.ResetTimer()
-	for i := range b.N {
-		m.Set(hashes[i%numEntries], uint64(i%numEntries))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		os.Remove(tmpDir + "/ctrl")
+		os.Remove(tmpDir + "/slots")
+		m, _, _ := NewSwissPositionMap(tmpDir+"/ctrl", tmpDir+"/slots", uint64(totalEntries), [32]byte{}, fileHashSource{dataFile}, testPositionMask)
+		b.StartTimer()
+
+		for off := 0; off+batchSize <= totalEntries; off += batchSize {
+			if err := m.SetBatch(hashes[off:off+batchSize], packeds); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.StopTimer()
+		m.Close()
+		b.StartTimer()
 	}
+	b.SetBytes(int64(totalEntries) * 32)
 }
 
 // BenchmarkGoMapGet benchmarks native Go map for comparison.


### PR DESCRIPTION
The newly added SetBatch allows for batched inserts.
The `HashAt` change instead of going through `ReaderAt` allows for a 0 alloc on a given `verifyHash`:

```
goos: linux
  goarch: amd64
  pkg: github.com/utreexo/utreexo/internal/swisstable
  cpu: AMD Ryzen 9 7950X3D 16-Core Processor
              │   pre.txt    │             post.txt              │
              │    sec/op    │   sec/op     vs base              │
  SwissGet-32   434.5n ± 1%   427.2n ± 1%  -1.68% (p=0.000 n=10)
  SwissSet-32   458.2n ± 1%   438.2n ± 1%  -4.36% (p=0.000 n=10)
  geomean       446.2n        432.7n       -3.03%

              │ pre.txt    │             post.txt              │
              │   B/op     │   B/op     vs base                │
  SwissGet-32   33.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)
  SwissSet-32   32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

              │  pre.txt    │             post.txt              │
              │  allocs/op  │ allocs/op   vs base               │
  SwissGet-32   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
  SwissSet-32   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

Lastly the swisstable growth to 4x forces less resize overall during ibd.