### PR TITLE
mmapcache: release physical pages on Clear via MADV_DONTNEED

### DIFF
--- a/internal/mmapcache/mmap_linux.go
+++ b/internal/mmapcache/mmap_linux.go
@@ -28,3 +28,13 @@ func mmapAnon(size int) ([]byte, error) {
 func mmapRelease(data []byte) {
 	_ = syscall.Munmap(data)
 }
+
+// madviseDontNeed tells the kernel to drop the physical pages backing the
+// given range. The virtual mapping stays intact; subsequent accesses fault
+// in fresh zero-filled pages. Used by Store.Clear to release resident
+// memory after a logical reset without re-mmapping the address space.
+// Errors are ignored: MADV_DONTNEED is advisory and a failure only means
+// the kernel kept pages it was free to drop, which is benign.
+func madviseDontNeed(data []byte) {
+	_ = syscall.Madvise(data, syscall.MADV_DONTNEED)
+}

--- a/internal/mmapcache/mmapcache.go
+++ b/internal/mmapcache/mmapcache.go
@@ -297,8 +297,14 @@ func (s *Store) Put(offset int64, data []byte) error {
 	}
 }
 
-// Clear removes all entries. The mmap regions remain allocated so the
-// store can be reused without re-mapping.
+// Clear removes all entries and releases the physical pages backing the
+// data region. The virtual mmap regions remain allocated so the store
+// can be reused without re-mapping; the kernel returns fresh zero-filled
+// pages on next access to the data region. The bitmap and dirty-bitmap
+// regions are NOT released because they are touched on every cache
+// operation and dropping them would just thrash the page tables. The
+// data region, by contrast, is accessed at scattered offsets and benefits
+// from being released.
 //
 // NOT safe for concurrent use with Get/Put.
 func (s *Store) Clear() {
@@ -313,6 +319,7 @@ func (s *Store) Clear() {
 	s.resetDirty()
 	s.presMinWord.Store(math.MaxInt64)
 	s.presMaxWord.Store(-1)
+	madviseDontNeed(s.data)
 }
 
 // Close releases all mmap regions back to the OS.


### PR DESCRIPTION
Store.Clear() resets the bitmap and dirty trackers but never releases the physical pages backing the data region. On Linux without swap, those pages stay resident until process exit, producing a monotonic anonymous-memory leak that scales with how many distinct slot offsets the cache has ever touched.

Call madvise(MADV_DONTNEED) on the data region inside Clear so the kernel returns the touched pages to the free list. The virtual mapping is preserved; subsequent accesses fault in fresh zero-filled pages. The bitmap regions are not advised because they are touched on every cache operation and dropping them would thrash the page tables.

Observed downstream as utreexod archive bridges (--prune=0 --flatutreexoproofindex) OOMing on 32GB machines: RssAnon climbed linearly at ~10 GB/hour during IBD. With this patch RssAnon oscillates 1-3 GB on the flush period instead of growing unbounded.