### PR TITLE
cached_rws: type cache field concretely for escape analysis

### DIFF
--- a/cache_mmap.go
+++ b/cache_mmap.go
@@ -8,6 +8,11 @@ import "github.com/utreexo/utreexo/internal/mmapcache"
 // interface used by cachedRWS.
 type mmapCacheStore struct{ s *mmapcache.Store }
 
+// cacheImpl is the concrete cache type cachedRWS stores. Using a concrete
+// type (rather than the cacheStore interface) lets escape analysis see
+// through cache.put so callers can pass values without heap-allocating.
+type cacheImpl = mmapCacheStore
+
 func newMmapCacheStore(entrySize int, maxBytes int64) (*mmapCacheStore, error) {
 	s, err := mmapcache.New(entrySize, maxBytes)
 	if err != nil {

--- a/cache_mmap_other.go
+++ b/cache_mmap_other.go
@@ -7,3 +7,7 @@ package utreexo
 func newMmapCacheStore(entrySize int, maxBytes int64) (*pageCacheStore, error) {
 	return newPageCacheStore(entrySize, maxBytes), nil
 }
+
+// cacheImpl is the concrete cache type cachedRWS stores. See the linux
+// build's cacheImpl comment for the rationale.
+type cacheImpl = pageCacheStore

--- a/cached_rws.go
+++ b/cached_rws.go
@@ -52,7 +52,11 @@ type cacheStore interface {
 // the underlying file.
 type cachedRWS struct {
 	underlying forestFile
-	cache      cacheStore
+	// cache is the concrete production cache type (build-tagged alias).
+	// Concrete dispatch lets escape analysis see through cache.put so
+	// callers like PutHashAt can pass [32]byte by value without forcing
+	// the local to heap.
+	cache      *cacheImpl
 	maxWritten atomic.Int64 // highest byte offset ever written (logical file size)
 	baseSize   int64        // underlying file size at last flush
 }


### PR DESCRIPTION
The cache field was typed as the cacheStore interface, so every call to c.cache.put went through dynamic dispatch and escape analysis had to assume the slice argument might be retained by the impl. That forced callers like PutHashAt to escape their value param onto the heap even when the underlying impl (mmapcache.Store.Put / pageCacheStore.put) only copies the bytes and never retains them.

Replace the interface field with a *cacheImpl pointer, where cacheImpl is a build-tagged type alias: mmapCacheStore on linux, pageCacheStore elsewhere. Concrete dispatch lets escape analysis see all the way through, so PutHashAt's [32]byte stays on the caller's stack.

cacheStore stays around for the cross-impl tests in cache_test.go.