### PR TITLE
.github: bump golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.7.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2"
       - name: Build
         run: go build ./...
       - name: Test

--- a/prove.go
+++ b/prove.go
@@ -2304,41 +2304,41 @@ func (c *CachingScheduleTracker) String() string {
 	// Write deletions
 	sb.WriteString("  deletions:\n")
 	for i, del := range c.deletions {
-		sb.WriteString(fmt.Sprintf("    [%d]: %v (translated %v)\n",
-			i, del, translatePositions(del, CSTTotalRows, TreeRows(c.numLeaves[i]))))
+		fmt.Fprintf(&sb, "    [%d]: %v (translated %v)\n",
+			i, del, translatePositions(del, CSTTotalRows, TreeRows(c.numLeaves[i])))
 	}
 
 	// Write ttls
 	sb.WriteString("  ttls:\n")
 	for i, ttl := range c.ttls {
-		sb.WriteString(fmt.Sprintf("    [%d]: %v\n",
-			i, ttl))
+		fmt.Fprintf(&sb, "    [%d]: %v\n",
+			i, ttl)
 	}
 
 	// Write numAdds
-	sb.WriteString(fmt.Sprintf("  numAdds: %v\n", c.numAdds))
+	fmt.Fprintf(&sb, "  numAdds: %v\n", c.numAdds)
 
 	// Write numLeaves
-	sb.WriteString(fmt.Sprintf("  numLeaves: %v\n", c.numLeaves))
+	fmt.Fprintf(&sb, "  numLeaves: %v\n", c.numLeaves)
 
 	// Write toDestroy
 	sb.WriteString("  toDestroy:\n")
 	for i, td := range c.toDestroy {
-		sb.WriteString(fmt.Sprintf("    [%d]: %v (translated %v)\n",
-			i, td, translatePositions(td, CSTTotalRows, TreeRows(c.numLeaves[i]))))
+		fmt.Fprintf(&sb, "    [%d]: %v (translated %v)\n",
+			i, td, translatePositions(td, CSTTotalRows, TreeRows(c.numLeaves[i])))
 	}
 
 	// Write roots
 	sb.WriteString("  roots:\n")
 	for i, rootList := range c.roots {
-		sb.WriteString(fmt.Sprintf("    [%d]: [", i))
+		fmt.Fprintf(&sb, "    [%d]: [", i)
 		for j, root := range rootList {
 			if j > 0 {
 				sb.WriteString(", ")
 			}
-			sb.WriteString(fmt.Sprintf("{pos: %d (translated %d), isZombie: %t}",
+			fmt.Fprintf(&sb, "{pos: %d (translated %d), isZombie: %t}",
 				root.pos, translatePos(root.pos, CSTTotalRows, TreeRows(c.numLeaves[i])),
-				root.isZombie))
+				root.isZombie)
 		}
 		sb.WriteString("]\n")
 	}


### PR DESCRIPTION
The v2.7.2 release tag was removed from GitHub, so the install step could no longer download it and CI failed at "Install Linters".