### PR TITLE
forest: bound the rehash pass to a memory window

### DIFF
--- a/forest.go
+++ b/forest.go
@@ -765,10 +765,12 @@ func (f *Forest) loadMetadata() error {
 		return nil
 	}
 
-	// The slot holds the leaf count the last rehash covered. Seed only when it
-	// still equals numLeaves, otherwise stay at 0 and rebuild from the first leaf.
-	if gen := binary.LittleEndian.Uint64(genSlot[:8]); gen != 0 && gen == f.NumLeaves {
-		f.lastGeneratedLeaves = gen
+	// A nonzero slot means no append cleared it (Record clears it), so every
+	// append since built its parent hashes and the forest is caught up: seed
+	// lastGeneratedLeaves from numLeaves, like the legacy path above. A zero slot
+	// or one ahead of numLeaves rebuilds from the first leaf.
+	if gen := binary.LittleEndian.Uint64(genSlot[:8]); gen != 0 && gen <= f.NumLeaves {
+		f.lastGeneratedLeaves = f.NumLeaves
 	}
 	return nil
 }

--- a/forest.go
+++ b/forest.go
@@ -269,6 +269,10 @@ type Forest struct {
 	NumLeaves  uint64
 	forestRows uint8 // Fixed maximum rows for stable position mapping
 
+	// addRehashWindow caps how many appended leaves one rehash pass
+	// materializes. Zero uses defaultAddRehashWindow.
+	addRehashWindow uint64
+
 	// positionMap maps leaf hashes to packed (addIndex, position) values.
 	// Upper 17 bits = addIndex (index within Modify batch), lower 47 bits = position.
 	// Only tracks leaves (row 0), not intermediate nodes.

--- a/forest_roots.go
+++ b/forest_roots.go
@@ -2,6 +2,7 @@ package utreexo
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/utreexo/utreexo/internal/rowwalk"
 	"golang.org/x/exp/slices"
@@ -246,12 +247,52 @@ func (f *Forest) rehashDeletionRow(affected []uint64, row uint8, numLeaves uint6
 	return parents, proof, nil
 }
 
-// processAddsParallel rebuilds the interior hashes for the leaves appended
-// between prevLeaves and totalLeaves, walking each affected position up to its
-// root one row at a time. At every row the rehash collapses each appended
-// sibling pair to a single parent computation; the per-row work is fanned
-// across the pipeline worker pool once a row reaches minParallelSize.
+// defaultAddRehashWindow caps how many appended leaves one rehash pass
+// materializes, so its memory is bounded. Forests override it via addRehashWindow.
+const defaultAddRehashWindow uint64 = 1 << 22
+
+// processAddsParallel rebuilds the parent hashes for the leaves appended between
+// prevLeaves and totalLeaves, one window at a time so a large backlog stays
+// bounded in memory. Each window extends the hashes like an appended block, so
+// its right edge resolves when the next window covers it, and the WAL cache is
+// spilled between windows. A single-window pass never flushes.
 func (f *Forest) processAddsParallel(prevLeaves, totalLeaves uint64, forestRows uint8) error {
+	window := f.addRehashWindow
+	if window == 0 {
+		window = defaultAddRehashWindow
+	}
+	for start := prevLeaves; start < totalLeaves; start += window {
+		end := start + window
+		if end > totalLeaves {
+			end = totalLeaves
+		}
+		if err := f.processAddsRange(start, end, forestRows); err != nil {
+			return err
+		}
+
+		// Spill the WAL cache at the committed bestHash so the node cache stays
+		// in budget. RehashAndProve holds f.mu, so flush directly. The marker
+		// stays behind, so a kill here redoes the pass from the first leaf.
+		if end < totalLeaves && f.FlushNeeded() {
+			var bestHash [32]byte
+			if _, err := f.metaFile.ReadAt(bestHash[:], bestHashOffset); err != nil && err != io.EOF {
+				return err
+			}
+			if err := f.wal.Flush(bestHash); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// processAddsRange rebuilds the interior hashes for the leaves appended between
+// prevLeaves and totalLeaves, walking each affected position up to its root one
+// row at a time. At every row the rehash collapses each appended sibling pair to
+// a single parent computation; the per-row work is fanned across the pipeline
+// worker pool once a row reaches minParallelSize.
+func (f *Forest) processAddsRange(prevLeaves, totalLeaves uint64, forestRows uint8) error {
 	numAdds := int(totalLeaves - prevLeaves)
 	if numAdds == 0 {
 		return nil

--- a/forest_roots_test.go
+++ b/forest_roots_test.go
@@ -1,6 +1,7 @@
 package utreexo
 
 import (
+	"encoding/binary"
 	"sort"
 	"testing"
 
@@ -250,6 +251,50 @@ func TestRehashAndProveFromZeroWindowed(t *testing.T) {
 	require.NoError(t, err)
 	defer f3.Close([32]byte{0x01})
 	require.Equal(t, uint64(numLeaves), f3.NumLeaves)
+}
+
+// TestLoadMetadataTrustsBehindMarker checks that a nonzero marker behind
+// NumLeaves is taken as caught up (lastGeneratedLeaves seeded from NumLeaves, no
+// rebuild), the shape an old binary leaves by advancing NumLeaves without it.
+func TestLoadMetadataTrustsBehindMarker(t *testing.T) {
+	const (
+		numLeaves = 3000
+		markAt    = 2000 // the marker is rewritten to this count, behind NumLeaves
+	)
+
+	dbpath := t.TempDir()
+	adds, _, _ := newSimChainWithSeed(0, 0x4D).NextBlock(numLeaves)
+
+	// Build a current forest, then rewrite the marker behind NumLeaves like an
+	// old binary that advances NumLeaves without touching it.
+	f, err := OpenForest(dbpath)
+	require.NoError(t, err)
+	require.NoError(t, f.Modify(adds, nil, Proof{}))
+
+	f.mu.Lock()
+	var markBuf [32]byte
+	binary.LittleEndian.PutUint64(markBuf[:], markAt)
+	require.NoError(t, f.metaFile.PutHashAt(markBuf, generatedLeavesOffset))
+	f.mu.Unlock()
+	require.NoError(t, f.Close([32]byte{0x01}))
+
+	// Reopen: the behind marker is taken as caught up, so lastGeneratedLeaves
+	// equals NumLeaves.
+	reopened, err := OpenForest(dbpath)
+	require.NoError(t, err)
+	defer reopened.Close([32]byte{0x01})
+	require.Equal(t, uint64(numLeaves), reopened.lastGeneratedLeaves)
+	require.Equal(t, uint64(numLeaves), reopened.NumLeaves)
+
+	// The forest is already caught up, so this returns the existing roots.
+	roots, _, _, err := reopened.RehashAndProve(nil)
+	require.NoError(t, err)
+
+	modifyForest, err := OpenForest(t.TempDir())
+	require.NoError(t, err)
+	defer modifyForest.Close([32]byte{})
+	require.NoError(t, modifyForest.Modify(adds, nil, Proof{}))
+	require.Equal(t, modifyForest.GetRoots(), roots)
 }
 
 func TestRehashDeletionsAndCaptureProof(t *testing.T) {

--- a/forest_roots_test.go
+++ b/forest_roots_test.go
@@ -206,6 +206,52 @@ func TestProcessAddsParallel(t *testing.T) {
 	}
 }
 
+// TestRehashAndProveFromZeroWindowed records leaves into a WAL forest whose cache
+// is far below the forest, then rebuilds from zero on reopen. The shrunk window
+// makes the pass cross many boundaries and the tiny cache makes it spill between
+// them and read boundary hashes back from disk. The roots must match Modify, and
+// the recorded NumLeaves must survive the reopen and the spills.
+func TestRehashAndProveFromZeroWindowed(t *testing.T) {
+	const numLeaves = 5000
+
+	dbpath := t.TempDir()
+	adds, _, _ := newSimChainWithSeed(0, 0x99).NextBlock(numLeaves)
+
+	want, err := OpenForest(t.TempDir())
+	require.NoError(t, err)
+	defer want.Close([32]byte{})
+	require.NoError(t, want.Modify(adds, nil, Proof{}))
+
+	// Record with a cache far below the forest, then close without rehashing: the
+	// marker-behind shape a kill during IBD record leaves.
+	f, err := OpenForest(dbpath, MaxCacheMemory(64*32))
+	require.NoError(t, err)
+	require.NoError(t, f.EnterRecordMode())
+	_, _, err = f.Record(simChainAddHashes(adds), nil)
+	require.NoError(t, err)
+	require.True(t, f.FlushNeeded(), "recorded leaves should overflow the tiny budget")
+	require.NoError(t, f.Close([32]byte{0x01}))
+
+	// Reopen and rebuild from zero: NumLeaves survives, and the pass spills between
+	// windows and reads boundary hashes back from disk to land the Modify roots.
+	f2, err := OpenForest(dbpath, MaxCacheMemory(64*32))
+	require.NoError(t, err)
+	f2.addRehashWindow = 64
+	require.Equal(t, uint64(numLeaves), f2.NumLeaves)
+	require.Zero(t, f2.lastGeneratedLeaves)
+
+	roots, _, _, err := f2.RehashAndProve(nil)
+	require.NoError(t, err)
+	require.Equal(t, want.GetRoots(), roots)
+	require.NoError(t, f2.Close([32]byte{0x01}))
+
+	// The spills during the rebuild must not have disturbed NumLeaves.
+	f3, err := OpenForest(dbpath)
+	require.NoError(t, err)
+	defer f3.Close([32]byte{0x01})
+	require.Equal(t, uint64(numLeaves), f3.NumLeaves)
+}
+
 func TestRehashDeletionsAndCaptureProof(t *testing.T) {
 	const forestRows = uint8(16)
 


### PR DESCRIPTION
RehashAndProve rebuilds the parent hashes for the leaves appended between lastGeneratedLeaves and NumLeaves. When that range spans the whole forest, as on a from-zero rebuild after lastGeneratedLeaves has fallen behind NumLeaves, the pass allocated three position slices sized to the range and buffered a parent hash for every leaf in the WAL cache. Both scale with the leaf count, so on a large forest the pass ran the process out of memory.

Rehash the range one window at a time. The per-pass scratch slices stay bounded to a window, and the WAL cache is spilled between windows once it reaches its budget so the node cache stays bounded too. The final window is excluded, so a single-window pass, which is the normal per-block case, never flushes.

The spill commits at the already-committed bestHash and leaves the numLeaves slot untouched, so a kill mid-rebuild reopens to the same recorded leaf count with lastGeneratedLeaves still behind and redoes the pass from the first leaf.

Tests cover the windowed from-zero rebuild against the Modify path, the mid-rebuild flush with read-back from disk, and that a flush leaves numLeaves intact across a reopen.